### PR TITLE
Keep only subtitle in trace

### DIFF
--- a/.changeset/sixty-books-search.md
+++ b/.changeset/sixty-books-search.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.top-antibodies.workflow": patch
+---
+
+Keep only subtitle in trace

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8293,7 +8293,7 @@ snapshots:
       oxfmt: 0.35.0
       oxlint: 1.43.0
       rolldown: 1.0.0-rc.14
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.9.1)(rollup@4.52.5)
       typescript: 5.9.3
@@ -8333,7 +8333,7 @@ snapshots:
       oxfmt: 0.35.0
       oxlint: 1.43.0
       rolldown: 1.0.0-rc.14
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.9.1)(rollup@4.52.5)
       typescript: 5.9.3
@@ -13856,7 +13856,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3)):
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3

--- a/workflow/src/filter-and-sample.tpl.tengo
+++ b/workflow/src/filter-and-sample.tpl.tengo
@@ -137,12 +137,12 @@ self.body(func(inputs) {
 
     // Create trace with filter descriptions and inject into exported columns
     traceLabel := inputs.filterTraceLabel
+    customBlockLabel := inputs.customBlockLabel
+    if !is_undefined(customBlockLabel) {
+        traceLabel = customBlockLabel
+    }
     if is_undefined(traceLabel) || traceLabel == "" {
         traceLabel = "Selected Leads"
-    }
-    customBlockLabel := inputs.customBlockLabel
-    if !is_undefined(customBlockLabel) && customBlockLabel != "" {
-        traceLabel = customBlockLabel + " / " + traceLabel
     }
     trace := pSpec.makeTrace(datasetSpec,
         {


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes how the trace label is composed in `filter-and-sample.tpl.tengo`: instead of concatenating `customBlockLabel` and `filterTraceLabel` as `"customBlockLabel / filterTraceLabel"`, the `customBlockLabel` now fully replaces `filterTraceLabel` when present, keeping only the subtitle in the trace.

- **`workflow/src/filter-and-sample.tpl.tengo`**: Logic reordered so `customBlockLabel` (when defined) replaces `filterTraceLabel` outright; the default `"Selected Leads"` fallback is still applied if the result is empty.
- **`pnpm-lock.yaml`**: Snapshot entries for `rolldown-plugin-dts` updated, with `vue-tsc@3.2.6`'s TypeScript peer resolution changing from `5.9.3` to `5.6.3` — this appears unrelated to the trace label change.
- **`.changeset/sixty-books-search.md`**: Patch changeset entry added for the workflow package.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the trace label change is straightforward and intentional, with only a minor edge-case gap around an empty `customBlockLabel` string.

The core logic change is clean and matches the PR's stated intent. The missing empty-string guard for `customBlockLabel` means a defined-but-empty custom label would silently discard a meaningful `filterTraceLabel`, which is a subtle behavioural shift from the prior code. The unrelated `vue-tsc` TypeScript peer downgrade in the lockfile is worth a second look.

`pnpm-lock.yaml` (unrelated peer dependency change) and `workflow/src/filter-and-sample.tpl.tengo` (empty-string guard).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workflow/src/filter-and-sample.tpl.tengo | Refactors trace label logic so `customBlockLabel` replaces rather than prepends to `filterTraceLabel`; missing empty-string guard for `customBlockLabel` could silently drop `filterTraceLabel`. |
| pnpm-lock.yaml | Lockfile snapshot for `rolldown-plugin-dts` updated; `vue-tsc@3.2.6` peer resolved to `typescript@5.6.3` instead of `5.9.3` — appears unrelated to this PR. |
| .changeset/sixty-books-search.md | New patch changeset entry for the workflow package describing the trace label change. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start: traceLabel = inputs.filterTraceLabel] --> B{is customBlockLabel defined?}
    B -- Yes --> C[traceLabel = customBlockLabel]
    B -- No --> D{is traceLabel undefined or empty?}
    C --> D
    D -- Yes --> E[traceLabel = 'Selected Leads']
    D -- No --> F[Use traceLabel as-is]
    E --> G[pSpec.makeTrace with label: traceLabel]
    F --> G
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
pnpm-lock.yaml:8296
**Unrelated TypeScript peer dependency downgrade in lockfile**

The `vue-tsc@3.2.6` peer resolution for `rolldown-plugin-dts` was changed from `typescript@5.9.3` to `typescript@5.6.3` in all three snapshot entries. This lowers `vue-tsc`'s effective TypeScript version while the workspace itself still resolves to `typescript@5.9.3`, which could cause subtle type-checking inconsistencies during DTS generation. This change appears unrelated to the trace label fix — worth confirming it was intentional (e.g. from an unrelated `pnpm install` run).

### Issue 2 of 2
workflow/src/filter-and-sample.tpl.tengo:140-143
**Empty `customBlockLabel` silently discards `filterTraceLabel`**

When `customBlockLabel` is defined but is an empty string `""`, the new code sets `traceLabel = ""` (overwriting whatever `filterTraceLabel` provided), and then falls back to `"Selected Leads"`. The old code guarded against this with `&& customBlockLabel != ""`, so a defined-but-empty `customBlockLabel` would have preserved `filterTraceLabel`. Adding the empty-string guard keeps the new "replace, don't concatenate" semantics while retaining the prior fallback behaviour.

```suggestion
    customBlockLabel := inputs.customBlockLabel
    if !is_undefined(customBlockLabel) && customBlockLabel != "" {
        traceLabel = customBlockLabel
    }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Keep only subtitle in trace"](https://github.com/platforma-open/antibody-tcr-lead-selection/commit/692064593cbf8c8b3096ba7054c97e07bf57bc46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31584261)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->