### PR TITLE
3d-structure-clustering label

### DIFF
--- a/.changeset/recognize-3d-clustering-trace.md
+++ b/.changeset/recognize-3d-clustering-trace.md
@@ -1,0 +1,8 @@
+---
+'@platforma-open/milaboratories.top-antibodies.model': patch
+'@platforma-open/milaboratories.top-antibodies': patch
+---
+
+Recognize 3d-structure-clustering linkers when populating the cluster-column dropdown. The label is now extracted from the producer block's clustering trace element for both clonotype-clustering and 3d-structure-clustering sources.
+
+Show the "Clone Id" axis-label column by default in the main lead-selection table (previously it was orderable but only visible from the optional-columns picker).

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -33,6 +33,14 @@ export { blockDataModel } from './dataModel';
 export type Href = InferHrefType<typeof platforma>;
 export type BlockOutputs = InferOutputsType<typeof platforma>;
 
+// Trace element types emitted by upstream clustering blocks. Lead-selection
+// pulls each linker's clustering label from these types when populating the
+// cluster-column dropdown; any new clustering producer must be added here.
+const CLUSTERING_TRACE_TYPES = [
+  'milaboratories.clonotype-clustering.clustering',
+  'milaboratories.3d-structure-clustering.clustering',
+];
+
 export const platforma = BlockModelV3.create(blockDataModel)
 
   .args<BlockArgs>((data) => {
@@ -408,13 +416,18 @@ export const platforma = BlockModelV3.create(blockDataModel)
               spec.name === 'pl7.app/ranking-order'
               || spec.name === 'pl7.app/vdj/inVivoScore'
               || isFilterOrRank(spec)
-              || (spec.annotations?.['pl7.app/vdj/isAssemblingFeature'] === 'true'
-                && spec.annotations?.['pl7.app/vdj/isMainSequence'] === 'true'
-                && spec.domain?.['pl7.app/alphabet'] === 'aminoacid')
-              || (spec.annotations?.['pl7.app/isAssemblingFeature'] === 'true'
-                && spec.annotations?.['pl7.app/isMainSequence'] === 'true'
-                && spec.domain?.['pl7.app/alphabet'] === 'aminoacid')
-              || (kabatEnabled && spec.name.startsWith('pl7.app/vdj/kabatSequence')),
+              || (spec.name === Annotation.Label
+                && spec.axesSpec.length === 1
+                && (spec.axesSpec[0].name === 'pl7.app/vdj/clonotypeKey'
+                  || spec.axesSpec[0].name === 'pl7.app/vdj/scClonotypeKey'
+                  || spec.axesSpec[0].name === 'pl7.app/variantKey'))
+                || (spec.annotations?.['pl7.app/vdj/isAssemblingFeature'] === 'true'
+                  && spec.annotations?.['pl7.app/vdj/isMainSequence'] === 'true'
+                  && spec.domain?.['pl7.app/alphabet'] === 'aminoacid')
+                || (spec.annotations?.['pl7.app/isAssemblingFeature'] === 'true'
+                  && spec.annotations?.['pl7.app/isMainSequence'] === 'true'
+                  && spec.domain?.['pl7.app/alphabet'] === 'aminoacid')
+                || (kabatEnabled && spec.name.startsWith('pl7.app/vdj/kabatSequence')),
             visibility: 'default',
           },
           // Clone-to-cluster mapping (name: pl7.app/clusterId, axes: [clonotypeKey])
@@ -534,7 +547,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
         },
       ], {
         label: {
-          forceTraceElements: ['milaboratories.clonotype-clustering.clustering'],
+          forceTraceElements: CLUSTERING_TRACE_TYPES,
         },
       });
 
@@ -548,7 +561,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
         let label = 'Cluster';
         try {
           const trace = JSON.parse(linkerSpec.annotations?.['pl7.app/trace'] ?? '[]') as { type?: string; label?: string }[];
-          const clusteringElement = trace.find((t) => t.type === 'milaboratories.clonotype-clustering.clustering');
+          const clusteringElement = trace.find((t) => CLUSTERING_TRACE_TYPES.includes(t.type ?? ''));
           if (clusteringElement?.label) label = clusteringElement.label;
         } catch { /* use default */ }
         options.push({ label, ref: link.ref });


### PR DESCRIPTION
Fix Clone label visibility, support 3d-structure-clustering labels

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds support for `3d-structure-clustering` labels in the cluster-column dropdown by extracting both clustering trace-element types into a shared `CLUSTERING_TRACE_TYPES` constant, and fixes Clone Id label column visibility so it appears by default in the lead-selection table.

- **`CLUSTERING_TRACE_TYPES` constant** — replaces the inline single-string array in both `forceTraceElements` and the `trace.find(...)` call; the `t.type ?? ''` guard also handles `undefined` type fields gracefully.
- **Label visibility** — adds a new `match` branch that makes any `Annotation.Label` column with a single clonotype/variant axis visible by default, resolving the previously hidden Clone Id column.
- **Changeset** — patch-level entry for both the model and the top-level package.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the changes are additive and isolated to label extraction and column visibility defaults.

Both the CLUSTERING_TRACE_TYPES constant and the forceTraceElements update are straightforward. The only thing worth a second look is the indentation of the assembling-feature and kabat conditions in the visibility match function, which visually suggests they're nested inside the new Label check, but are actually independent top-level disjunctions — the logic is unchanged, only the formatting is misleading.

The visibility match lambda in model/src/index.ts around the new Label condition.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model/src/index.ts | Extracts CLUSTERING_TRACE_TYPES constant to support both clonotype-clustering and 3d-structure-clustering label sources; adds Clone/Label axis visibility rule to the default-visible set. Misleading indentation in the visibility match function (cosmetic only — logic is unchanged). |
| .changeset/recognize-3d-clustering-trace.md | New patch-level changeset entry accurately describing both the 3d-structure-clustering label fix and the Clone Id default-visibility change. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[linkerSpec with trace annotation] --> B[Parse trace JSON array]
    B --> C{Find element where\ntype in CLUSTERING_TRACE_TYPES}
    C -->|clonotype-clustering| D[Use element.label]
    C -->|3d-structure-clustering| D
    C -->|not found| E[Use default 'Cluster']
    D --> F[Push option to dropdown]
    E --> F

    G[PColumnSpec] --> H{visibility match}
    H -->|ranking-order / inVivoScore| I[default]
    H -->|isFilterOrRank| I
    H -->|Annotation.Label + single clonotype axis| I
    H -->|isAssemblingFeature + aminoacid| I
    H -->|kabatEnabled + kabatSequence| I
    H -->|isClusterIdAxisName| J[hidden]
    H -->|not a linker column| K[optional]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
model/src/index.ts:419-430
The closing `))` on line 423 terminates both inner parentheses, so the subsequent `||` branches (assembling-feature, isAssemblingFeature, kabat) are top-level disjunctions — they are NOT nested inside the Label condition. The current indentation (two extra spaces) makes them visually appear to be part of the Label group, which could mislead future maintainers into thinking only specs that also pass the Label check will be shown by default.

```suggestion
              || (spec.name === Annotation.Label
                && spec.axesSpec.length === 1
                && (spec.axesSpec[0].name === 'pl7.app/vdj/clonotypeKey'
                  || spec.axesSpec[0].name === 'pl7.app/vdj/scClonotypeKey'
                  || spec.axesSpec[0].name === 'pl7.app/variantKey'))
              || (spec.annotations?.['pl7.app/vdj/isAssemblingFeature'] === 'true'
                && spec.annotations?.['pl7.app/vdj/isMainSequence'] === 'true'
                && spec.domain?.['pl7.app/alphabet'] === 'aminoacid')
              || (spec.annotations?.['pl7.app/isAssemblingFeature'] === 'true'
                && spec.annotations?.['pl7.app/isMainSequence'] === 'true'
                && spec.domain?.['pl7.app/alphabet'] === 'aminoacid')
              || (kabatEnabled && spec.name.startsWith('pl7.app/vdj/kabatSequence')),
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Clone label visibility, support 3d-s..."](https://github.com/platforma-open/antibody-tcr-lead-selection/commit/73fbf24ef775b13b728a9b4e5ffece74a9f61fc3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33069262)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->