### PR TITLE
Add dataset selector with optional filter dropdown

### DIFF
--- a/.changeset/filter-dropdown-primary-ref.md
+++ b/.changeset/filter-dropdown-primary-ref.md
@@ -1,0 +1,8 @@
+---
+'@platforma-open/milaboratories.top-antibodies.model': minor
+'@platforma-open/milaboratories.top-antibodies.ui': minor
+'@platforma-open/milaboratories.top-antibodies.workflow': minor
+'@platforma-open/milaboratories.top-antibodies': minor
+---
+
+Add dataset selector with optional filter dropdown. Replaces the plain dataset dropdown with `PlDatasetSelector`, and inner-joins the selected filter column into the clone table so it narrows every downstream stage (final clonotypes, spectratype, Kabat).

--- a/model/src/dataModel.ts
+++ b/model/src/dataModel.ts
@@ -1,5 +1,16 @@
-import { createPlDataTableStateV2, DataModelBuilder } from '@platforma-sdk/model';
-import type { BlockData, BlockData_Ver_2026_02_25, LegacyBlockArgs, LegacyUiState } from './types';
+import {
+  createDatasetSelection,
+  createPlDataTableStateV2,
+  createPrimaryRef,
+  DataModelBuilder,
+} from '@platforma-sdk/model';
+import type {
+  BlockData,
+  BlockData_Ver_2026_02_25,
+  BlockData_Ver_2026_05_08,
+  LegacyBlockArgs,
+  LegacyUiState,
+} from './types';
 import { getDefaultBlockLabel } from './util';
 
 const defaultSelectionPlotState = (): BlockData['selectionPlotState'] => ({
@@ -42,10 +53,19 @@ export const blockDataModel = new DataModelBuilder()
     rankingsInitializedForAnchor: uiState?.rankingsInitializedForAnchor,
     preset: uiState?.preset,
   }))
-  .migrate<BlockData>('Ver_2026_05_08', (prev) => ({
+  .migrate<BlockData_Ver_2026_05_08>('Ver_2026_05_08', (prev) => ({
     ...prev,
     selectionPlotState: defaultSelectionPlotState(),
   }))
+  .migrate<BlockData>('Ver_2026_05_21', (prev) => {
+    const { inputAnchor, ...rest } = prev;
+    return {
+      ...rest,
+      input: inputAnchor !== undefined
+        ? createDatasetSelection(createPrimaryRef(inputAnchor))
+        : undefined,
+    };
+  })
   .init(() => ({
     defaultBlockLabel: getDefaultBlockLabel({}),
     customBlockLabel: '',

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -8,27 +8,30 @@ import type {
   PColumnIdAndSpec,
   PColumnSpec,
   PlRef,
+  PObjectSpec,
   PTableSorting,
 } from '@platforma-sdk/model';
 import {
   Annotation,
   ArrayColumnProvider,
   BlockModelV3,
+  buildDatasetOptions,
   canonicalizeJson,
   createPFrameForGraphs,
   createPlDataTableV3,
   deriveLabels,
   isHiddenFromGraphColumn,
   isHiddenFromUIColumn,
+  isPColumnSpec,
 } from '@platforma-sdk/model';
-import { buildCollection, commonExcludeSelectors, IN_VIVO_SCORE_COLUMN_ID, isClusterIdAxisName, isSelectableMatch, matchToColumnId } from './util';
+import { buildCollection, commonExcludeSelectors, getInputAnchorRef, getInputFilterRef, IN_VIVO_SCORE_COLUMN_ID, isClusterIdAxisName, isSelectableMatch, matchToColumnId } from './util';
 import { convertFilterUI, convertRankingOrderUI } from './converters';
 import { blockDataModel } from './dataModel';
 import type { BlockArgs } from './types';
 
 export * from './types';
 export * from './converters';
-export { getDefaultBlockLabel } from './util';
+export { getDefaultBlockLabel, getInputAnchorRef, getInputFilterRef } from './util';
 export { blockDataModel } from './dataModel';
 export type Href = InferHrefType<typeof platforma>;
 export type BlockOutputs = InferOutputsType<typeof platforma>;
@@ -44,7 +47,8 @@ const CLUSTERING_TRACE_TYPES = [
 export const platforma = BlockModelV3.create(blockDataModel)
 
   .args<BlockArgs>((data) => {
-    if (data.inputAnchor === undefined) throw new Error('No input anchor');
+    const inputAnchor = getInputAnchorRef(data);
+    if (inputAnchor === undefined) throw new Error('No input anchor');
     if (data.topClonotypes === undefined) throw new Error('No top clonotypes');
 
     const rankingOrder = convertRankingOrderUI(data.rankingOrder);
@@ -57,7 +61,8 @@ export const platforma = BlockModelV3.create(blockDataModel)
     return {
       defaultBlockLabel: data.defaultBlockLabel,
       customBlockLabel: data.customBlockLabel,
-      inputAnchor: data.inputAnchor,
+      inputAnchor,
+      inputFilter: getInputFilterRef(data),
       topClonotypes: data.topClonotypes,
       rankingOrder,
       filters,
@@ -66,36 +71,33 @@ export const platforma = BlockModelV3.create(blockDataModel)
     };
   })
 
-  .output('inputOptions', (ctx) =>
-    ctx.resultPool.getOptions([{
-      axes: [
-        { name: 'pl7.app/sampleId' },
-        { name: 'pl7.app/vdj/clonotypeKey' },
-      ],
-      annotations: { 'pl7.app/isAnchor': 'true' },
-    }, {
-      axes: [
-        { name: 'pl7.app/sampleId' },
-        { name: 'pl7.app/vdj/scClonotypeKey' },
-      ],
-      annotations: { 'pl7.app/isAnchor': 'true' },
-    }, {
-      axes: [
-        { name: 'pl7.app/sampleId' },
-        { name: 'pl7.app/variantKey' },
-      ],
-      annotations: { 'pl7.app/isAnchor': 'true' },
-    }], { refsWithEnrichments: true }),
+  // Dataset picker entries. Predicate accepts any anchor column whose row axis
+  // is clonotypeKey, scClonotypeKey, or variantKey — the three modalities this
+  // block supports. Filter slot is unrestricted: any subset column with a
+  // compatible axis spec qualifies (e.g. lead-selection links, custom subsets).
+  .output('datasetOptions', (ctx) =>
+    buildDatasetOptions(ctx, {
+      primary: (spec: PObjectSpec): boolean => {
+        if (!isPColumnSpec(spec)) return false;
+        if (spec.annotations?.['pl7.app/isAnchor'] !== 'true') return false;
+        if (spec.axesSpec.length < 2) return false;
+        if (spec.axesSpec[0]?.name !== 'pl7.app/sampleId') return false;
+        const rowAxis = spec.axesSpec[1]?.name;
+        return rowAxis === 'pl7.app/vdj/clonotypeKey'
+          || rowAxis === 'pl7.app/vdj/scClonotypeKey'
+          || rowAxis === 'pl7.app/variantKey';
+      },
+    }),
   )
 
   .output('inputAnchorSpec', (ctx) => {
-    const ref = ctx.data.inputAnchor;
+    const ref = getInputAnchorRef(ctx.data);
     if (ref === undefined) return undefined;
     return ctx.resultPool.getPColumnSpecByRef(ref);
   }, { retentive: true })
 
   .output('modality', (ctx) => {
-    const ref = ctx.data.inputAnchor;
+    const ref = getInputAnchorRef(ctx.data);
     if (ref === undefined) return undefined;
     const spec = ctx.resultPool.getPColumnSpecByRef(ref);
     if (!spec) return undefined;
@@ -104,7 +106,8 @@ export const platforma = BlockModelV3.create(blockDataModel)
 
   // Combined filter config - options and defaults together for atomic updates
   .output('filterConfig', (ctx) => {
-    const result = buildCollection(ctx, ctx.data.inputAnchor);
+    const inputAnchor = getInputAnchorRef(ctx.data);
+    const result = buildCollection(ctx, inputAnchor);
     if (!result) return undefined;
 
     const filterableMatches = result.collection.findColumns({
@@ -120,7 +123,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
     );
     const options = labeled.map(({ value, label }) => ({
       label,
-      value: matchToColumnId(value, ctx.data.inputAnchor!),
+      value: matchToColumnId(value, inputAnchor!),
       column: value.column,
     }));
 
@@ -135,7 +138,8 @@ export const platforma = BlockModelV3.create(blockDataModel)
 
   // Combined ranking config - options and defaults together for atomic updates
   .output('rankingConfig', (ctx) => {
-    const result = buildCollection(ctx, ctx.data.inputAnchor);
+    const inputAnchor = getInputAnchorRef(ctx.data);
+    const result = buildCollection(ctx, inputAnchor);
     if (!result) return undefined;
 
     const rankableMatches = result.collection.findColumns({
@@ -153,7 +157,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
     );
     const options = labeled.map(({ value, label }) => ({
       label,
-      value: matchToColumnId(value, ctx.data.inputAnchor!),
+      value: matchToColumnId(value, inputAnchor!),
     }));
 
     // Add synthetic In Vivo Score option when mutation columns are present
@@ -161,7 +165,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
       options.unshift({
         label: 'In Vivo Score',
         value: {
-          anchorRef: ctx.data.inputAnchor!,
+          anchorRef: inputAnchor!,
           anchorName: 'main',
           column: IN_VIVO_SCORE_COLUMN_ID,
         },
@@ -178,7 +182,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
   }, { retentive: true })
 
   .output('presetConfig', (ctx) => {
-    const result = buildCollection(ctx, ctx.data.inputAnchor);
+    const result = buildCollection(ctx, getInputAnchorRef(ctx.data));
     if (!result) return undefined;
 
     return {
@@ -189,7 +193,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
   }, { retentive: true })
 
   .outputWithStatus('pf', (ctx) => {
-    const anchor = ctx.data.inputAnchor;
+    const anchor = getInputAnchorRef(ctx.data);
     if (!anchor) return undefined;
 
     const result = buildCollection(ctx, anchor);
@@ -447,7 +451,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
   })
 
   .output('calculating', (ctx) => {
-    if (ctx.data.inputAnchor === undefined)
+    if (getInputAnchorRef(ctx.data) === undefined)
       return false;
 
     if (!ctx.outputs) return false;
@@ -460,7 +464,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
 
   // Use UMAP output from ctx from clonotype-space block
   .outputWithStatus('umapPf', (ctx) => {
-    const anchor = ctx.data.inputAnchor;
+    const anchor = getInputAnchorRef(ctx.data);
     if (anchor === undefined)
       return undefined;
 
@@ -483,7 +487,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
   })
 
   .outputWithStatus('umapPcols', (ctx) => {
-    const anchor = ctx.data.inputAnchor;
+    const anchor = getInputAnchorRef(ctx.data);
     if (anchor === undefined)
       return undefined;
 
@@ -512,7 +516,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
   })
 
   .output('hasClusterData', (ctx) => {
-    const result = buildCollection(ctx, ctx.data.inputAnchor);
+    const result = buildCollection(ctx, getInputAnchorRef(ctx.data));
     if (!result) return false;
 
     return result.meta.allMatches.some((m) =>
@@ -521,7 +525,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
   })
 
   .output('clusterColumnOptions', (ctx) => {
-    const anchor = ctx.data.inputAnchor;
+    const anchor = getInputAnchorRef(ctx.data);
     if (anchor === undefined)
       return undefined;
 
@@ -588,7 +592,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
   .subtitle((ctx) => ctx.data.customBlockLabel || ctx.data.defaultBlockLabel)
 
   .sections((ctx) => {
-    const ref = ctx.data?.inputAnchor;
+    const ref = getInputAnchorRef(ctx.data);
     const isPeptide = ref !== undefined
       && ctx.resultPool.getPColumnSpecByRef(ref)?.axesSpec[1]?.name === 'pl7.app/variantKey';
 

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -71,12 +71,15 @@ export const platforma = BlockModelV3.create(blockDataModel)
     };
   })
 
-  // Dataset picker entries. Predicate accepts any anchor column whose row axis
-  // is clonotypeKey, scClonotypeKey, or variantKey — the three modalities this
-  // block supports. Filter slot is unrestricted: any subset column with a
-  // compatible axis spec qualifies (e.g. lead-selection links, custom subsets).
-  .output('datasetOptions', (ctx) =>
-    buildDatasetOptions(ctx, {
+  // Dataset picker entries. Primary accepts any anchor column whose row axis
+  // is clonotypeKey, scClonotypeKey, or variantKey — the three modalities
+  // this block supports. After building, drop filter entries that came from
+  // *this* block instance (matched by `ref.blockId` against the
+  // workflow-exposed `selfBlockId`) — otherwise every completed run would
+  // surface its own sampled subset as a filter on the next configuration.
+  // Filter entries from *other* lead-selection instances are kept.
+  .output('datasetOptions', (ctx) => {
+    const opts = buildDatasetOptions(ctx, {
       primary: (spec: PObjectSpec): boolean => {
         if (!isPColumnSpec(spec)) return false;
         if (spec.annotations?.['pl7.app/isAnchor'] !== 'true') return false;
@@ -87,8 +90,26 @@ export const platforma = BlockModelV3.create(blockDataModel)
           || rowAxis === 'pl7.app/vdj/scClonotypeKey'
           || rowAxis === 'pl7.app/variantKey';
       },
-    }),
-  )
+    });
+    if (!opts) return opts;
+
+    // selfBlockId only exists once the block has produced outputs at least
+    // once. Before that there are no self-filter entries to drop anyway.
+    const selfBlockId = ctx.outputs?.resolve({
+      field: 'selfBlockId',
+      assertFieldType: 'Input',
+      allowPermanentAbsence: true,
+    })?.getDataAsJson<string>();
+    if (selfBlockId === undefined) return opts;
+
+    return opts.map((opt) => {
+      const filtered = opt.filters?.filter((f) => f.ref.blockId !== selfBlockId);
+      return {
+        ...opt,
+        filters: filtered && filtered.length > 0 ? filtered : undefined,
+      };
+    });
+  })
 
   .output('inputAnchorSpec', (ctx) => {
     const ref = getInputAnchorRef(ctx.data);

--- a/model/src/types.ts
+++ b/model/src/types.ts
@@ -1,5 +1,5 @@
 import type { GraphMakerState } from '@milaboratories/graph-maker';
-import type { ColumnMatch, DataInfo, PColumn, PColumnValues, PlDataTableStateV2, PlMultiSequenceAlignmentModel, PlRef, PObjectId, TreeNodeAccessor } from '@platforma-sdk/model';
+import type { ColumnMatch, DatasetSelection, DataInfo, PColumn, PColumnValues, PlDataTableStateV2, PlMultiSequenceAlignmentModel, PlRef, PObjectId, TreeNodeAccessor } from '@platforma-sdk/model';
 import type { PlTableFilter } from './typesFilters';
 
 export * from './typesFilters';
@@ -55,14 +55,29 @@ export type BlockData_Ver_2026_02_25 = {
   preset?: WorkflowPreset;
 };
 
-export type BlockData = BlockData_Ver_2026_02_25 & {
+export type BlockData_Ver_2026_05_08 = BlockData_Ver_2026_02_25 & {
   selectionPlotState: GraphMakerState;
+};
+
+export type BlockData = Omit<BlockData_Ver_2026_05_08, 'inputAnchor'> & {
+  /**
+   * Dataset selection emitted by `PlDatasetSelector` (primary anchor + optional
+   * filter). Replaces the previous `inputAnchor: PlRef`; the args lambda
+   * unpacks it into the workflow's `inputAnchor` + `inputFilter`.
+   */
+  input?: DatasetSelection;
 };
 
 export type BlockArgs = {
   defaultBlockLabel: string;
   customBlockLabel: string;
   inputAnchor?: PlRef;
+  /**
+   * Optional filter column the user picked alongside the dataset in
+   * `PlDatasetSelector`. The workflow inner-joins this column into the clone
+   * table so all downstream stages see only the filtered clonotypes.
+   */
+  inputFilter?: PlRef;
   topClonotypes: number;
   rankingOrder: RankingOrder[];
   filters: Filter[];

--- a/model/src/util.ts
+++ b/model/src/util.ts
@@ -11,6 +11,16 @@ import {
 } from '@platforma-sdk/model';
 import type { BlockArgs, BlockData, ColumnsMeta, PlTableFiltersDefault, RankingOrder, ScopedColumnId, WorkflowPreset } from './types';
 
+/** Underlying primary `PlRef` from `data.input` — undefined when no dataset is picked. */
+export function getInputAnchorRef(data: Pick<BlockData, 'input'>): PlRef | undefined {
+  return data.input?.primary.column;
+}
+
+/** Optional filter `PlRef` the user picked alongside the primary in `PlDatasetSelector`. */
+export function getInputFilterRef(data: Pick<BlockData, 'input'>): PlRef | undefined {
+  return data.input?.primary.filter;
+}
+
 /** Common WASM exclude selectors shared across filter/rank/table discovery. */
 export const commonExcludeSelectors: NonNullable<AnchoredFindColumnsOptions['exclude']> = [
   { annotations: { 'pl7.app/isLinkerColumn': 'true' } },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: ^0.0.3
       version: 0.0.3
     '@platforma-sdk/block-tools':
-      specifier: 2.8.0
-      version: 2.8.0
+      specifier: 2.8.2
+      version: 2.8.2
     '@platforma-sdk/eslint-config':
       specifier: 1.2.0
       version: 1.2.0
@@ -100,7 +100,7 @@ importers:
         version: 2.29.8(@types/node@24.9.1)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.0
+        version: 2.8.2
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -125,7 +125,7 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.0
+        version: 2.8.2
 
   model:
     dependencies:
@@ -150,7 +150,7 @@ importers:
         version: 1.2.3
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.0
+        version: 2.8.2
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.38.0)(@stylistic/eslint-plugin@2.13.0(eslint@9.38.0)(typescript@5.6.3))(eslint-plugin-n@17.23.1(eslint@9.38.0)(typescript@5.6.3))(eslint-plugin-vue@9.33.0(eslint@9.38.0))(eslint@9.38.0)(globals@15.15.0)(typescript-eslint@8.46.2(eslint@9.38.0)(typescript@5.6.3))(typescript@5.6.3)
@@ -1147,6 +1147,10 @@ packages:
     resolution: {integrity: sha512-/mBCy4IfS/sR8allgq3XfBBBxjEY0lcwbN8xxS2U+SWKaWVkgQZgQFRek8RmWAST6Qsnl60TvY6RpeAq2JBTCw==}
     engines: {node: '>=22.19.0'}
 
+  '@milaboratories/pl-client@3.8.1':
+    resolution: {integrity: sha512-x2Y1xooxtEttIfj60JSGMUDdTsAk3RrmlOmuuytwgq82RfDpAAa1M1XHBfuCUNoAjDP1e6BgU9rk4ZhOMGBf9A==}
+    engines: {node: '>=22.19.0'}
+
   '@milaboratories/pl-config@1.8.1':
     resolution: {integrity: sha512-moh8YNeSXRkBaH5IQhrzcWoehM6EMwfVFx2Y4vP6eEwphbHDqPLdhn6COkEJlYijH6kT00JdWjlUrvx+MZD9Cw==}
 
@@ -1176,6 +1180,9 @@ packages:
 
   '@milaboratories/pl-model-backend@1.3.0':
     resolution: {integrity: sha512-fY0FobfDtE+ZN6D6yrPgNo/28pwjQt/KeYeJTcfFVcDAEv8kltxfb7hhE36nl7Af27msodvZVtEmDNqWP/xKuQ==}
+
+  '@milaboratories/pl-model-backend@1.3.2':
+    resolution: {integrity: sha512-1w4Jcl2vk7w8foWztKthDryQCPrkefW+5hXIwSNsNIB40o0v83p4zoqMGBrrm9b2MJUPoFyliTkAsp+J1UQu9g==}
 
   '@milaboratories/pl-model-common@1.36.0':
     resolution: {integrity: sha512-BbFs3sTmy12ZKfTY6rFep0C5pfQoLvsjACN8EYaNIjXqOjQajt6velh4uGpB47+Uyp78k0cIWH4T04MIlixQrw==}
@@ -1661,6 +1668,10 @@ packages:
 
   '@platforma-sdk/block-tools@2.8.0':
     resolution: {integrity: sha512-3IjwEz4grmpA6Xxrpsg4jkKqvasMUofEiyKAnWs4uXAj+IR5BI18yS8Rc1Akzz2TOgq0qvFcRqjElb7Qfg3CpA==}
+    hasBin: true
+
+  '@platforma-sdk/block-tools@2.8.2':
+    resolution: {integrity: sha512-9+rqqx0XAWNfo+P6rA95UqRFMLZckbZ3W/xPi53zt+vYqgCLehZM+KnGROOk0w5NxiTsudB2JJSbeM2WyQUnxQ==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -8295,6 +8306,24 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.1
 
+  '@milaboratories/pl-client@3.8.1':
+    dependencies:
+      '@grpc/grpc-js': 1.13.4
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/ts-helpers': 1.8.2
+      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+      canonicalize: 2.1.0
+      denque: 2.1.0
+      long: 5.3.2
+      lru-cache: 11.2.2
+      openapi-fetch: 0.15.0
+      undici: 7.16.0
+      utility-types: 3.11.0
+      yaml: 2.8.1
+
   '@milaboratories/pl-config@1.8.1':
     dependencies:
       '@milaboratories/ts-helpers': 1.8.2
@@ -8406,6 +8435,12 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
+  '@milaboratories/pl-model-backend@1.3.2':
+    dependencies:
+      '@milaboratories/pl-client': 3.8.1
+      canonicalize: 2.1.0
+      zod: 3.25.76
+
   '@milaboratories/pl-model-common@1.36.0':
     dependencies:
       '@milaboratories/helpers': 1.14.1
@@ -8468,7 +8503,7 @@ snapshots:
       oxlint: 1.63.0
       oxlint-plugin-eslint: 1.63.0
       rolldown: 1.0.0-rc.14
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.9.1)(rollup@4.52.5)
       typescript: 5.9.3
@@ -8509,7 +8544,7 @@ snapshots:
       oxlint: 1.63.0
       oxlint-plugin-eslint: 1.63.0
       rolldown: 1.0.0-rc.14
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.9.1)(rollup@4.52.5)
       typescript: 5.9.3
@@ -8960,6 +8995,28 @@ snapshots:
       '@aws-sdk/client-s3': 3.859.0
       '@milaboratories/pl-http': 1.2.4
       '@milaboratories/pl-model-backend': 1.3.0
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-middle-layer': 1.20.0
+      '@milaboratories/resolve-helper': 1.1.3
+      '@milaboratories/ts-helpers': 1.8.2
+      '@milaboratories/ts-helpers-oclif': 1.1.41
+      '@oclif/core': 4.7.2
+      '@platforma-sdk/blocks-deps-updater': 2.2.0
+      canonicalize: 2.1.0
+      lru-cache: 11.2.2
+      mime-types: 2.1.35
+      tar: 7.5.1
+      undici: 7.16.0
+      yaml: 2.8.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@platforma-sdk/block-tools@2.8.2':
+    dependencies:
+      '@aws-sdk/client-s3': 3.859.0
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-backend': 1.3.2
       '@milaboratories/pl-model-common': 1.42.0
       '@milaboratories/pl-model-middle-layer': 1.20.0
       '@milaboratories/resolve-helper': 1.1.3
@@ -14174,7 +14231,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3)):
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,14 +10,14 @@ catalogs:
       specifier: ^2.29.8
       version: 2.29.8
     '@milaboratories/graph-maker':
-      specifier: 1.4.2
-      version: 1.4.2
+      specifier: 1.4.3
+      version: 1.4.3
     '@milaboratories/helpers':
       specifier: 1.14.2
       version: 1.14.2
     '@milaboratories/multi-sequence-alignment':
-      specifier: 1.47.12
-      version: 1.47.12
+      specifier: 1.47.13
+      version: 1.47.13
     '@milaboratories/strings':
       specifier: 0.1.2
       version: 0.1.2
@@ -34,29 +34,29 @@ catalogs:
       specifier: ^0.0.3
       version: 0.0.3
     '@platforma-sdk/block-tools':
-      specifier: 2.8.2
-      version: 2.8.2
+      specifier: 2.9.0
+      version: 2.9.0
     '@platforma-sdk/eslint-config':
       specifier: 1.2.0
       version: 1.2.0
     '@platforma-sdk/model':
-      specifier: 1.77.4
-      version: 1.77.4
+      specifier: 1.77.11
+      version: 1.77.11
     '@platforma-sdk/package-builder':
       specifier: 3.12.0
       version: 3.12.0
     '@platforma-sdk/tengo-builder':
-      specifier: 3.0.0
-      version: 3.0.0
+      specifier: 3.0.3
+      version: 3.0.3
     '@platforma-sdk/test':
-      specifier: 1.77.4
-      version: 1.77.4
+      specifier: 1.77.11
+      version: 1.77.11
     '@platforma-sdk/ui-vue':
-      specifier: 1.77.4
-      version: 1.77.4
+      specifier: 1.77.11
+      version: 1.77.11
     '@platforma-sdk/workflow-tengo':
-      specifier: 5.21.0
-      version: 5.21.0
+      specifier: 5.26.0
+      version: 5.26.0
     '@types/lodash.debounce':
       specifier: ^4.0.9
       version: 4.0.9
@@ -100,7 +100,7 @@ importers:
         version: 2.29.8(@types/node@24.9.1)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.2
+        version: 2.9.0
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -125,13 +125,13 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.2
+        version: 2.9.0
 
   model:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.3(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.11)(@platforma-sdk/ui-vue@1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/helpers':
         specifier: 'catalog:'
         version: 1.14.2
@@ -140,7 +140,7 @@ importers:
         version: 0.1.2
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.77.4
+        version: 1.77.11
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
@@ -150,13 +150,13 @@ importers:
         version: 1.2.3
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.2
+        version: 2.9.0
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.38.0)(@stylistic/eslint-plugin@2.13.0(eslint@9.38.0)(typescript@5.6.3))(eslint-plugin-n@17.23.1(eslint@9.38.0)(typescript@5.6.3))(eslint-plugin-vue@9.33.0(eslint@9.38.0))(eslint@9.38.0)(globals@15.15.0)(typescript-eslint@8.46.2(eslint@9.38.0)(typescript@5.6.3))(typescript@5.6.3)
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+        version: 1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@types/node':
         specifier: 'catalog:'
         version: 24.9.1
@@ -229,7 +229,7 @@ importers:
         version: 1.2.0(@eslint/js@9.38.0)(@stylistic/eslint-plugin@2.13.0(eslint@9.38.0)(typescript@5.6.3))(eslint-plugin-n@17.23.1(eslint@9.38.0)(typescript@5.6.3))(eslint-plugin-vue@9.33.0(eslint@9.38.0))(eslint@9.38.0)(globals@15.15.0)(typescript-eslint@8.46.2(eslint@9.38.0)(typescript@5.6.3))(typescript@5.6.3)
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.77.4(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.9.1)(vite@8.0.7(@types/node@24.9.1)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1))
+        version: 1.77.11(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.9.1)(vite@8.0.7(@types/node@24.9.1)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1))
       typescript:
         specifier: 'catalog:'
         version: 5.6.3
@@ -241,10 +241,10 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.3(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.11)(@platforma-sdk/ui-vue@1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/multi-sequence-alignment':
         specifier: 'catalog:'
-        version: 1.47.12(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.47.13(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.11)(@platforma-sdk/ui-vue@1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
@@ -253,10 +253,10 @@ importers:
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.77.4
+        version: 1.77.11
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+        version: 1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@types/lodash.debounce':
         specifier: 'catalog:'
         version: 4.0.9
@@ -314,11 +314,11 @@ importers:
         version: link:../software/umap
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 5.21.0
+        version: 5.26.0
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 3.0.0
+        version: 3.0.3
 
 packages:
 
@@ -1090,8 +1090,8 @@ packages:
     resolution: {integrity: sha512-MgUqC3/8cE41k01dV8yne+K0bUYA457XFP7b/Sf5QrxDp6zWqCpWuCgLlsUzJNzFFLXaODWnpAFUvOZyQcq4jg==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/graph-maker@1.4.2':
-    resolution: {integrity: sha512-MIGMuVsT7QisCJNBCzXYqfBDQ5rjLpEbP8xeUoL23KKi/MjKeg/S2Srn/znWcTFtOFYdWOQjaPoaqcCEKvvICg==}
+  '@milaboratories/graph-maker@1.4.3':
+    resolution: {integrity: sha512-67FjRlIolHpMLQYKgvHxjmZXe9bijVvM0vyfgrzwvXW51FxtREpiRjwBJWbmnAALw++vcrLVhuN+lAyhVpSQfw==}
     peerDependencies:
       '@platforma-sdk/model': 1.73.3
       '@platforma-sdk/ui-vue': 1.73.3
@@ -1104,27 +1104,27 @@ packages:
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/miplots4@1.2.0':
-    resolution: {integrity: sha512-tUJkqB6yCj/HxSrxWvmiCulluPwhIy1538e93cz/P9t2OqAXCumkyGbXwNKwwSRxitiVVjqG26rZbMQBctykdA==}
+  '@milaboratories/miplots4@1.2.1':
+    resolution: {integrity: sha512-W9a9bVbW/zsHWSVadhK1ZETdXLdfhrzdPaig9Mr/6Nl9Hn0oHEX94D6pXCgGyfGV5zi7h/rY1pB0l7YUmsP3uA==}
 
-  '@milaboratories/multi-sequence-alignment@1.47.12':
-    resolution: {integrity: sha512-K0blTkxdxEi1ZWrTUAlSpqqBK9Kj2rZvs8SX+p56p9Z6bjg6CAZa3PYC7zCgggwZamP+S0rTziuha9W9cWZwUw==}
+  '@milaboratories/multi-sequence-alignment@1.47.13':
+    resolution: {integrity: sha512-71PbFOil/+uPOurkkMtj/+9pYMLfx8o79bBgXCw0b98OYBTMseGXYw94vFemPqsFnZX2mVk6kwm/1oz41gZhxg==}
     peerDependencies:
       '@platforma-sdk/model': 1.73.3
       '@platforma-sdk/ui-vue': 1.73.3
 
-  '@milaboratories/pf-driver@1.4.12':
-    resolution: {integrity: sha512-KVe2guqrvmQxaqGIfmfwiGzYkoiBDZBUp50zlnbWygxuZx4A2VuVDMYr66BkaYAnmxcCXq/Fm5YCwpYqtcH54Q==}
+  '@milaboratories/pf-driver@1.4.14':
+    resolution: {integrity: sha512-HdYdtCPFC6fThf7CU3Z5Wl/icQtEL7GIusBZrGkvgdrcxdopIWPxHdiCsQc1TSt3uSutqIn/hkFUOH7tZGYZPg==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pf-plots@1.4.1':
-    resolution: {integrity: sha512-qcJ/vzZLtxBi4mPGAvM1vQuBZfC2YYHLTTkJbsJUeWwfOjQg/YEuxoHkN58LXHnd6s0pcc7clAtpwdq0Y8JONQ==}
+  '@milaboratories/pf-plots@1.4.2':
+    resolution: {integrity: sha512-c24NW5LVAgj5j7WhM+8i3yT1G9l4sOLtqgkOCN/uWFQu3aReArzLOHNXjvztSk1pVPQZP9QjOCgKObOBHh9sDg==}
     peerDependencies:
       '@milaboratories/pl-model-common': 1.39.0
       '@platforma-sdk/model': 1.73.3
 
-  '@milaboratories/pf-spec-driver@1.3.17':
-    resolution: {integrity: sha512-ShmOxNr8ocgZJiOaSC1bD23L1+oqwiaPS5Hh8Bqa9FO1FP7DWPMWV0LtVuUr7ZRGLzivjh9ccQbMyK9QuP5pbg==}
+  '@milaboratories/pf-spec-driver@1.3.19':
+    resolution: {integrity: sha512-gqEYJsE74e8cQ7RFUXZPFt7Tkv5HMUGIDnW6Fh8GEu/aPCto/AAviYkFkYB2eZEoyFPMCkTNg3XFYt5lGFszZg==}
 
   '@milaboratories/pframes-rs-node@1.1.35':
     resolution: {integrity: sha512-XGLRa29bOmpEUeHgpWNDYZDGDFvR7OfXqaodxaIAVtXnsrsjxzDz063z1sjRPDOx/Pz9T+5n4iRNuLyygwcQ5A==}
@@ -1143,23 +1143,19 @@ packages:
       '@milaboratories/pl-model-common': 1.36.0
       '@milaboratories/pl-model-middle-layer': 1.18.5
 
-  '@milaboratories/pl-client@3.7.0':
-    resolution: {integrity: sha512-/mBCy4IfS/sR8allgq3XfBBBxjEY0lcwbN8xxS2U+SWKaWVkgQZgQFRek8RmWAST6Qsnl60TvY6RpeAq2JBTCw==}
-    engines: {node: '>=22.19.0'}
-
-  '@milaboratories/pl-client@3.8.1':
-    resolution: {integrity: sha512-x2Y1xooxtEttIfj60JSGMUDdTsAk3RrmlOmuuytwgq82RfDpAAa1M1XHBfuCUNoAjDP1e6BgU9rk4ZhOMGBf9A==}
+  '@milaboratories/pl-client@3.9.0':
+    resolution: {integrity: sha512-YTVLhS9ZhxQAnPOgChNM23TyzlfNd8WiAHnL9TccbBUMUmHsGhLyH3Ys6bOnGdlO9UKWZFQ+co96m2B9WZxjxw==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-config@1.8.1':
     resolution: {integrity: sha512-moh8YNeSXRkBaH5IQhrzcWoehM6EMwfVFx2Y4vP6eEwphbHDqPLdhn6COkEJlYijH6kT00JdWjlUrvx+MZD9Cw==}
 
-  '@milaboratories/pl-deployments@2.17.18':
-    resolution: {integrity: sha512-KCAlKdturtyxKkrwLvNBq3nSpxT9FeOFIBay0RyJLpMs+FzJ842LGtdSa7j8+N71BbPnFk43Ed/0MsbUZHG2MQ==}
+  '@milaboratories/pl-deployments@3.0.1':
+    resolution: {integrity: sha512-ZtgkXDPLNQJ0S5gAqLBl2RClwNbCKf0BLucL6y6ZJ5cezzw8Mq1yLtPHnxFmSwU7IV7dhfo3dlXBgofb9ysYxg==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-drivers@1.14.9':
-    resolution: {integrity: sha512-vYqOLIAnmpieKo2uIwQxw8TpU/xqQf2K52q5+4iekX9qkjxUh1ShUVMkWjzkttFa2Lp2Wpb+iqOuink7X8/Jow==}
+  '@milaboratories/pl-drivers@1.14.12':
+    resolution: {integrity: sha512-b1mXACFAUxnFwqP55CtycW8ghGRbbBQ6ZJ5MiqiascpcOmW9yhq49ooEOkbpYvrKUqAKmKz8Myv/mGGIw8tWbA==}
     engines: {node: '>=22'}
 
   '@milaboratories/pl-error-like@1.12.10':
@@ -1168,21 +1164,22 @@ packages:
   '@milaboratories/pl-error-like@1.12.9':
     resolution: {integrity: sha512-9qlfawLFO4qG656ayvVSRholhhwlfXUvKKllXpHadqbnf2zO2oCd+5J76bPaFXDz/A3T+1eokCnCX74JsqCYSw==}
 
-  '@milaboratories/pl-errors@1.4.9':
-    resolution: {integrity: sha512-98Ua9g5Vw4dyjJIeuW4HZcNqj+SpGT3qRsZQ+nWR80Um34I23vhOXjNqFO9cga6fXEjVe8ihkQ0qqYtrvjikCA==}
+  '@milaboratories/pl-errors@1.4.12':
+    resolution: {integrity: sha512-nhIPquOih6OKkLYMkDMzvUjWdn/m0X0lIQ6gNbAsWvpmv+KaOFp6noRPVqfGuvYuwwydPWZwGcEaG1zR7JBMrg==}
+
+  '@milaboratories/pl-healthcheck@1.0.0':
+    resolution: {integrity: sha512-tuSg+bwacmt9Z5gOkiarmX7jwYJttA+9rqXKaatwnPgjP+nAI40hyZtOZPHzJFEzWd4AKaGxrJbNxdB/xMG/ww==}
+    engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.61.0':
-    resolution: {integrity: sha512-xO7HT2Ggs+vCiQ6yTCZy3oWFxKb+Q0vL1fwP6FEUUOQnNXjy4D5zVGA9ZzAN8SWwri5dVgidH8fG70VfTlCUcg==}
+  '@milaboratories/pl-middle-layer@1.61.7':
+    resolution: {integrity: sha512-vevgshwn5TcKKY4Eu0o1px5hEH1O0yXIO1IaT2NAdf15dc3UeAtWAi4V1AWAdcQi/PgXhMnLL/PHUAEYrXoAOw==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-model-backend@1.3.0':
-    resolution: {integrity: sha512-fY0FobfDtE+ZN6D6yrPgNo/28pwjQt/KeYeJTcfFVcDAEv8kltxfb7hhE36nl7Af27msodvZVtEmDNqWP/xKuQ==}
-
-  '@milaboratories/pl-model-backend@1.3.2':
-    resolution: {integrity: sha512-1w4Jcl2vk7w8foWztKthDryQCPrkefW+5hXIwSNsNIB40o0v83p4zoqMGBrrm9b2MJUPoFyliTkAsp+J1UQu9g==}
+  '@milaboratories/pl-model-backend@1.3.3':
+    resolution: {integrity: sha512-lXOLgKjgteuDnOgf3CMrT13TdD4z36CC8Lail1nvlHKF+ZDbd+nNvsCbIQ5UA/AUVQCd3ucGOacgX2soc/+TyQ==}
 
   '@milaboratories/pl-model-common@1.36.0':
     resolution: {integrity: sha512-BbFs3sTmy12ZKfTY6rFep0C5pfQoLvsjACN8EYaNIjXqOjQajt6velh4uGpB47+Uyp78k0cIWH4T04MIlixQrw==}
@@ -1193,11 +1190,11 @@ packages:
   '@milaboratories/pl-model-middle-layer@1.18.5':
     resolution: {integrity: sha512-eIYE77rBva0k2KWDUmKJBHnGcyi/Tnc5rhlwZVb8q3hS3L4Upf4Pk7/lBL4ZLxYVMZ3/Da0Wp3EKYspUagi9Zg==}
 
-  '@milaboratories/pl-model-middle-layer@1.20.0':
-    resolution: {integrity: sha512-RGEJD0avNEBejl1SjCqn7RWNiK15xCNWMXfNziiHUcG4n+QxYm1sk5AezfWsKE3j3y1HdzZnYaoGto9Z1RoV7A==}
+  '@milaboratories/pl-model-middle-layer@1.22.0':
+    resolution: {integrity: sha512-MvdNkgPDaAoHnVU3IeeyGfZ9SynJwjsYKnvxNi3YQ9BzztwCDmSwrDijsVvo7lUBoeqLiXvLSr9ug98frKF6yg==}
 
-  '@milaboratories/pl-tree@1.11.2':
-    resolution: {integrity: sha512-l/n/AM4RK8Ey9U+601VPGipsuE5zdcm6TmHzMMnqYJV/8mqo6EKSaX/T32YcVhbptjtFwVGyJr4yEPIZrD3dNw==}
+  '@milaboratories/pl-tree@1.12.2':
+    resolution: {integrity: sha512-mVPrNnTORqFI0fWsutHdQBk5fBX9eSwCx1hDFBoiCW+89seQCtvr19bDAsQnTd+CkWGCWQmP+95bUS56ElplyQ==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/ptabler-expression-js@1.2.25':
@@ -1231,8 +1228,8 @@ packages:
     resolution: {integrity: sha512-bQHcEAeJXyV95Gyk0yoRS5t3M71mFaNG+SsY2o+i4GDDeByUXBiF+T5A0elc/rCyLK6NNlOblou0DHBYOiW3pQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.14.11':
-    resolution: {integrity: sha512-6I20gxijl8AKIZFWDItWs6cut+v3G0sN3uOhUVTrRW8V77B+f/8e8+HKs+b9F/r5QQ0xP6nJN2nuO+a/EblZcw==}
+  '@milaboratories/uikit@2.14.13':
+    resolution: {integrity: sha512-9klk/6DDheX6NotsIZ4h+FSZolc6VzMBchTVzZb+bmazmh9RQnmlGLUjqiP1/xOuSMAm2w6xUKbTSbSg07EY0A==}
 
   '@napi-rs/wasm-runtime@1.1.3':
     resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
@@ -1666,12 +1663,8 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries@2.0.4':
     resolution: {integrity: sha512-q8dAJ/RwAR35uKj74Bvzq4lpuBLxzuCNkuCH4suwb2ybDyEggL0XUB26aUuf15hX+6rFVulyBaQToXURKVKwzw==}
 
-  '@platforma-sdk/block-tools@2.8.0':
-    resolution: {integrity: sha512-3IjwEz4grmpA6Xxrpsg4jkKqvasMUofEiyKAnWs4uXAj+IR5BI18yS8Rc1Akzz2TOgq0qvFcRqjElb7Qfg3CpA==}
-    hasBin: true
-
-  '@platforma-sdk/block-tools@2.8.2':
-    resolution: {integrity: sha512-9+rqqx0XAWNfo+P6rA95UqRFMLZckbZ3W/xPi53zt+vYqgCLehZM+KnGROOk0w5NxiTsudB2JJSbeM2WyQUnxQ==}
+  '@platforma-sdk/block-tools@2.9.0':
+    resolution: {integrity: sha512-pC3n4izYPIMnC8ADkwg7dZWhEaNYeHd0zAbTkWVRj5Pnprl03gqaT2jfpr6+KGT13T7gADIywhWmy5UW7dl4ew==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -1690,29 +1683,26 @@ packages:
       typescript: ~5.6.3
       typescript-eslint: ^8.17.0
 
-  '@platforma-sdk/model@1.77.4':
-    resolution: {integrity: sha512-YJ/IsURqdaNnOf9JNw8dfmwaZQz1JhEqqR76jK7tmEH7y5ZOKB8mc5Hp3A/x7Wp/9JcXLAVY84h8s6R86FPl4w==}
+  '@platforma-sdk/model@1.77.11':
+    resolution: {integrity: sha512-qWu0flWA2vx0wAOzw0pQQzT1HZq4PrYRJVmImpg+htHDAt6KdbCc0d9XQnWpy2gMp4IcZ73rmeW+0tsUC4hshQ==}
 
   '@platforma-sdk/package-builder@3.12.0':
     resolution: {integrity: sha512-bId52YqV5iLDAn9D9C3xaLD1bKyymGpHe2CDEZTqV+1yWCBh1RM6iH96JIXudVJdcmJaqwJWDw6X4WzStE6SCg==}
     hasBin: true
 
-  '@platforma-sdk/tengo-builder@3.0.0':
-    resolution: {integrity: sha512-HfKoCZLHKwfdgwXqpYcp/gBxrFix5C8BJfkwSybZ3XNvFMcl+gvvwhFfmOwwY+TEcbiqNx21Z1GPFD5prY3g/A==}
+  '@platforma-sdk/tengo-builder@3.0.3':
+    resolution: {integrity: sha512-I0zv1iy0UaiShkMGXBZIyB3DnhI6qo8GE9oDzdj0Eql+tESLOGr4iD30UFddW2b68AR6zpsqdREa9OxfGuKgxQ==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.77.4':
-    resolution: {integrity: sha512-gPwItuUeH2xzhZArRvroTL/mcm1Gw4o9hajbJDWfd/zq6nXmwMQZuDGHfkeGB0Vng1EvMetEq+26ACZWDcXb7g==}
+  '@platforma-sdk/test@1.77.11':
+    resolution: {integrity: sha512-kAevtkLrAEV9k2eoNQyImKCATLaKLfj9g+gRUIB22CclwG7zReP5L3yajU6MnWPYU0g7Ns8G6Sn6EAtYkUqQMA==}
 
-  '@platforma-sdk/ui-vue@1.77.4':
-    resolution: {integrity: sha512-7P0+OGqu/BMhuvSqeEi/aBrrA9yCGPhs6jmcJlnP/rqCtwz2+M/CTvaYji7zI5U1htpiN877DdfKezdWUj43oA==}
+  '@platforma-sdk/ui-vue@1.77.11':
+    resolution: {integrity: sha512-rjrGZXeBqFJHQoAQjNv0T49BnnkGLDW/t3hqdn0VzXbc+4C7s1n60hLqBS5J0CB254Vk8toBvOOsrsFTZeFTQQ==}
 
-  '@platforma-sdk/workflow-tengo@5.21.0':
-    resolution: {integrity: sha512-E4+d19UIKPlo5/SDzunIFtS9uzXAfpGurT3C2U3q/InkDbAU/mSeJ6ENggvC4od+mymg8btWq3NmUIciqaqgFg==}
-
-  '@platforma-sdk/workflow-tengo@5.25.0':
-    resolution: {integrity: sha512-uLRwbgq7tHUVtQ+y+iVe40Cf2S9ept8+Q0dBGVlegvxsAqQPOQxhQkkHYvbH6zLmaf237bISME1rL1MxRs2ujQ==}
+  '@platforma-sdk/workflow-tengo@5.26.0':
+    resolution: {integrity: sha512-lXoFzD0LsQqEF9WUkA48avAY7LOK9WdP7sIc/Bymu1fOm4peXEWWZFW7fYckCPhHEAwcyzjqh7jdE8pVXrfzvw==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -8145,14 +8135,14 @@ snapshots:
       '@types/node': 24.5.2
       utility-types: 3.11.0
 
-  '@milaboratories/graph-maker@1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/graph-maker@1.4.3(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.11)(@platforma-sdk/ui-vue@1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@ag-grid-community/core': 32.3.9
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/miplots4': 1.2.0(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.1(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)
-      '@platforma-sdk/model': 1.77.4
-      '@platforma-sdk/ui-vue': 1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@milaboratories/miplots4': 1.2.1(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
+      '@milaboratories/pf-plots': 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.11)
+      '@platforma-sdk/model': 1.77.11
+      '@platforma-sdk/ui-vue': 1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@types/d3-hierarchy': 3.1.7
       '@types/d3-scale': 4.0.9
       '@vueuse/core': 13.9.0(vue@3.5.25(typescript@5.6.3))
@@ -8173,7 +8163,7 @@ snapshots:
 
   '@milaboratories/helpers@1.14.2': {}
 
-  '@milaboratories/miplots4@1.2.0(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)':
+  '@milaboratories/miplots4@1.2.1(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)':
     dependencies:
       '@d3fc/d3fc-chart': 5.1.9(d3-array@3.2.4)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)
       '@d3fc/d3fc-pointer': 3.0.3(d3-dispatch@3.0.1)(d3-selection@3.0.0)
@@ -8200,7 +8190,7 @@ snapshots:
       d3-shape: 3.2.0
       d3-zoom: 3.0.0
       kdbush: 4.0.2
-      lodash: 4.17.21
+      lodash: 4.18.1
       rbush: 4.0.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -8211,14 +8201,14 @@ snapshots:
       - d3-scale-chromatic
       - supports-color
 
-  '@milaboratories/multi-sequence-alignment@1.47.12(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/multi-sequence-alignment@1.47.13(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.11)(@platforma-sdk/ui-vue@1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@milaboratories/biowasm-tools': 2.0.2
-      '@milaboratories/miplots4': 1.2.0(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.1(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)
-      '@platforma-sdk/model': 1.77.4
-      '@platforma-sdk/ui-vue': 1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
-      vue: 3.5.24(typescript@5.6.3)
+      '@milaboratories/miplots4': 1.2.1(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
+      '@milaboratories/pf-plots': 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.11)
+      '@platforma-sdk/model': 1.77.11
+      '@platforma-sdk/ui-vue': 1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      vue: 3.5.25(typescript@5.6.3)
     transitivePeerDependencies:
       - '@milaboratories/pl-model-common'
       - d3-dispatch
@@ -8227,13 +8217,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@milaboratories/pf-driver@1.4.12(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-driver@1.4.14(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pframes-rs-node': 1.1.35
-      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.20.0)
+      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.22.0)
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.20.0
+      '@milaboratories/pl-model-middle-layer': 1.22.0
       '@milaboratories/ts-helpers': 1.8.2
       es-toolkit: 1.40.0
       lru-cache: 11.2.2
@@ -8242,20 +8232,20 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pf-plots@1.4.1(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)':
+  '@milaboratories/pf-plots@1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.11)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.42.0
-      '@platforma-sdk/model': 1.77.4
+      '@platforma-sdk/model': 1.77.11
       canonicalize: 2.1.0
-      lodash: 4.17.21
+      lodash: 4.18.1
 
-  '@milaboratories/pf-spec-driver@1.3.17(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-spec-driver@1.3.19(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.20.0)
+      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.22.0)
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.20.0
+      '@milaboratories/pl-model-middle-layer': 1.22.0
       '@noble/hashes': 2.0.1
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
@@ -8281,32 +8271,14 @@ snapshots:
 
   '@milaboratories/pframes-rs-wasip2@1.1.35': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.20.0)':
+  '@milaboratories/pframes-rs-wasm@1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.22.0)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
       '@milaboratories/pframes-rs-wasip2': 1.1.35
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.20.0
+      '@milaboratories/pl-model-middle-layer': 1.22.0
 
-  '@milaboratories/pl-client@3.7.0':
-    dependencies:
-      '@grpc/grpc-js': 1.13.4
-      '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/ts-helpers': 1.8.2
-      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
-      '@protobuf-ts/runtime': 2.11.1
-      '@protobuf-ts/runtime-rpc': 2.11.1
-      canonicalize: 2.1.0
-      denque: 2.1.0
-      long: 5.3.2
-      lru-cache: 11.2.2
-      openapi-fetch: 0.15.0
-      undici: 7.16.0
-      utility-types: 3.11.0
-      yaml: 2.8.1
-
-  '@milaboratories/pl-client@3.8.1':
+  '@milaboratories/pl-client@3.9.0':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
@@ -8330,9 +8302,10 @@ snapshots:
       upath: 2.0.1
       yaml: 2.8.1
 
-  '@milaboratories/pl-deployments@2.17.18':
+  '@milaboratories/pl-deployments@3.0.1':
     dependencies:
       '@milaboratories/pl-config': 1.8.1
+      '@milaboratories/pl-healthcheck': 1.0.0
       '@milaboratories/pl-http': 1.2.4
       '@milaboratories/pl-model-common': 1.42.0
       '@milaboratories/ts-helpers': 1.8.2
@@ -8344,14 +8317,14 @@ snapshots:
       yaml: 2.8.1
       zod: 3.25.76
 
-  '@milaboratories/pl-drivers@1.14.9':
+  '@milaboratories/pl-drivers@1.14.12':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/computable': 2.9.4
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-client': 3.7.0
+      '@milaboratories/pl-client': 3.9.0
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-tree': 1.11.2
+      '@milaboratories/pl-tree': 1.12.2
       '@milaboratories/ts-helpers': 1.8.2
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/plugin': 2.11.1
@@ -8379,38 +8352,46 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.23.8
 
-  '@milaboratories/pl-errors@1.4.9':
+  '@milaboratories/pl-errors@1.4.12':
     dependencies:
-      '@milaboratories/pl-client': 3.7.0
+      '@milaboratories/pl-client': 3.9.0
       '@milaboratories/ts-helpers': 1.8.2
       zod: 3.25.76
+
+  '@milaboratories/pl-healthcheck@1.0.0':
+    dependencies:
+      '@grpc/grpc-js': 1.13.4
+      '@milaboratories/ts-helpers': 1.8.2
+      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
 
   '@milaboratories/pl-http@1.2.4':
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.61.0(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pl-middle-layer@1.61.7(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/computable': 2.9.4
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pf-driver': 1.4.12(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pf-spec-driver': 1.3.17(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pf-driver': 1.4.14(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pf-spec-driver': 1.3.19(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pframes-rs-node': 1.1.35
-      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.20.0)
-      '@milaboratories/pl-client': 3.7.0
-      '@milaboratories/pl-deployments': 2.17.18
-      '@milaboratories/pl-drivers': 1.14.9
-      '@milaboratories/pl-errors': 1.4.9
+      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.22.0)
+      '@milaboratories/pl-client': 3.9.0
+      '@milaboratories/pl-deployments': 3.0.1
+      '@milaboratories/pl-drivers': 1.14.12
+      '@milaboratories/pl-errors': 1.4.12
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.3.0
+      '@milaboratories/pl-model-backend': 1.3.3
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.20.0
-      '@milaboratories/pl-tree': 1.11.2
+      '@milaboratories/pl-model-middle-layer': 1.22.0
+      '@milaboratories/pl-tree': 1.12.2
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.2
-      '@platforma-sdk/block-tools': 2.8.0
-      '@platforma-sdk/model': 1.77.4
-      '@platforma-sdk/workflow-tengo': 5.25.0
+      '@platforma-sdk/block-tools': 2.9.0
+      '@platforma-sdk/model': 1.77.11
+      '@platforma-sdk/workflow-tengo': 5.26.0
       canonicalize: 2.1.0
       denque: 2.1.0
       es-toolkit: 1.40.0
@@ -8429,15 +8410,9 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@milaboratories/pl-model-backend@1.3.0':
+  '@milaboratories/pl-model-backend@1.3.3':
     dependencies:
-      '@milaboratories/pl-client': 3.7.0
-      canonicalize: 2.1.0
-      zod: 3.25.76
-
-  '@milaboratories/pl-model-backend@1.3.2':
-    dependencies:
-      '@milaboratories/pl-client': 3.8.1
+      '@milaboratories/pl-client': 3.9.0
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -8463,7 +8438,7 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.20.0':
+  '@milaboratories/pl-model-middle-layer@1.22.0':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.42.0
@@ -8471,11 +8446,11 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-tree@1.11.2':
+  '@milaboratories/pl-tree@1.12.2':
     dependencies:
       '@milaboratories/computable': 2.9.4
-      '@milaboratories/pl-client': 3.7.0
-      '@milaboratories/pl-errors': 1.4.9
+      '@milaboratories/pl-client': 3.9.0
+      '@milaboratories/pl-errors': 1.4.12
       '@milaboratories/ts-helpers': 1.8.2
       denque: 2.1.0
       utility-types: 3.11.0
@@ -8588,10 +8563,10 @@ snapshots:
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.14.11(typescript@5.6.3)':
+  '@milaboratories/uikit@2.14.13(typescript@5.6.3)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@platforma-sdk/model': 1.77.4
+      '@platforma-sdk/model': 1.77.11
       '@types/d3-array': 3.2.2
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -8990,35 +8965,13 @@ snapshots:
       '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.5
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.5
 
-  '@platforma-sdk/block-tools@2.8.0':
+  '@platforma-sdk/block-tools@2.9.0':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.3.0
+      '@milaboratories/pl-model-backend': 1.3.3
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.20.0
-      '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.2
-      '@milaboratories/ts-helpers-oclif': 1.1.41
-      '@oclif/core': 4.7.2
-      '@platforma-sdk/blocks-deps-updater': 2.2.0
-      canonicalize: 2.1.0
-      lru-cache: 11.2.2
-      mime-types: 2.1.35
-      tar: 7.5.1
-      undici: 7.16.0
-      yaml: 2.8.1
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@platforma-sdk/block-tools@2.8.2':
-    dependencies:
-      '@aws-sdk/client-s3': 3.859.0
-      '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.3.2
-      '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.20.0
+      '@milaboratories/pl-model-middle-layer': 1.22.0
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.2
       '@milaboratories/ts-helpers-oclif': 1.1.41
@@ -9049,12 +9002,12 @@ snapshots:
       typescript: 5.6.3
       typescript-eslint: 8.46.2(eslint@9.38.0)(typescript@5.6.3)
 
-  '@platforma-sdk/model@1.77.4':
+  '@platforma-sdk/model@1.77.11':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-error-like': 1.12.10
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.20.0
+      '@milaboratories/pl-model-middle-layer': 1.22.0
       '@milaboratories/ptabler-expression-js': 1.2.25
       canonicalize: 2.1.0
       es-toolkit: 1.40.0
@@ -9080,23 +9033,23 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@platforma-sdk/tengo-builder@3.0.0':
+  '@platforma-sdk/tengo-builder@3.0.3':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.3.0
+      '@milaboratories/pl-model-backend': 1.3.3
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
       '@milaboratories/ts-helpers': 1.8.2
       '@oclif/core': 4.7.2
       winston: 3.18.3
 
-  '@platforma-sdk/test@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.9.1)(vite@8.0.7(@types/node@24.9.1)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1))':
+  '@platforma-sdk/test@1.77.11(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.9.1)(vite@8.0.7(@types/node@24.9.1)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1))':
     dependencies:
       '@milaboratories/computable': 2.9.4
-      '@milaboratories/pl-client': 3.7.0
-      '@milaboratories/pl-middle-layer': 1.61.0(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-tree': 1.11.2
-      '@platforma-sdk/model': 1.77.4
-      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
+      '@milaboratories/pl-client': 3.9.0
+      '@milaboratories/pl-middle-layer': 1.61.7(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-tree': 1.12.2
+      '@platforma-sdk/model': 1.77.11
+      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3(@types/node@24.9.1)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.16(@types/node@24.9.1)(lightningcss@1.32.0)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))(vite@8.0.7(@types/node@24.9.1)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))
       vitest: 4.1.3(@types/node@24.9.1)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.16(@types/node@24.9.1)(lightningcss@1.32.0)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))(vite@8.0.7(@types/node@24.9.1)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1))
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
@@ -9119,12 +9072,12 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
+  '@platforma-sdk/ui-vue@1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
     dependencies:
-      '@milaboratories/pf-spec-driver': 1.3.17(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pf-spec-driver': 1.3.19(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/uikit': 2.14.11(typescript@5.6.3)
-      '@platforma-sdk/model': 1.77.4
+      '@milaboratories/uikit': 2.14.13(typescript@5.6.3)
+      '@platforma-sdk/model': 1.77.11
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.1
@@ -9155,14 +9108,7 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/workflow-tengo@5.21.0':
-    dependencies:
-      '@milaboratories/software-pframes-conv': 2.2.9
-      '@platforma-open/milaboratories.software-ptabler': 1.16.1
-      '@platforma-open/milaboratories.software-ptexter': 1.2.2
-      '@platforma-open/milaboratories.software-small-binaries': 2.0.4
-
-  '@platforma-sdk/workflow-tengo@5.25.0':
+  '@platforma-sdk/workflow-tengo@5.26.0':
     dependencies:
       '@milaboratories/pframes-rs-wasip2': 1.1.35
       '@milaboratories/software-pframes-conv': 2.2.9
@@ -12127,7 +12073,7 @@ snapshots:
       vite: 8.0.7(@types/node@24.9.1)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)
       vue: 3.5.25(typescript@5.6.3)
 
-  '@vitest/coverage-istanbul@4.1.3(vitest@4.1.3)':
+  '@vitest/coverage-istanbul@4.1.3(vitest@4.1.3(@types/node@24.9.1)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.16(@types/node@24.9.1)(lightningcss@1.32.0)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))(vite@8.0.7(@types/node@24.9.1)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))':
     dependencies:
       '@babel/core': 7.29.0
       '@istanbuljs/schema': 0.1.3
@@ -14954,7 +14900,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.9.1
-      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
+      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3(@types/node@24.9.1)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.16(@types/node@24.9.1)(lightningcss@1.32.0)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))(vite@8.0.7(@types/node@24.9.1)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,17 +14,17 @@ catalog:
   # SDK packages - EXACT VERSIONS (no ^ or ~)
   '@milaboratories/ts-builder': 1.5.0
   '@milaboratories/ts-configs': 1.2.3
-  '@platforma-sdk/workflow-tengo': 5.21.0
-  '@platforma-sdk/model': 1.77.4
-  '@platforma-sdk/ui-vue': 1.77.4
-  '@platforma-sdk/tengo-builder': 3.0.0
+  '@platforma-sdk/workflow-tengo': 5.26.0
+  '@platforma-sdk/model': 1.77.11
+  '@platforma-sdk/ui-vue': 1.77.11
+  '@platforma-sdk/tengo-builder': 3.0.3
   '@platforma-sdk/package-builder': 3.12.0
-  '@platforma-sdk/block-tools': 2.8.2
+  '@platforma-sdk/block-tools': 2.9.0
   '@platforma-sdk/eslint-config': 1.2.0
-  '@platforma-sdk/test': 1.77.4
+  '@platforma-sdk/test': 1.77.11
   '@milaboratories/helpers': 1.14.2
-  '@milaboratories/graph-maker': 1.4.2
-  '@milaboratories/multi-sequence-alignment': 1.47.12
+  '@milaboratories/graph-maker': 1.4.3
+  '@milaboratories/multi-sequence-alignment': 1.47.13
   '@milaboratories/strings': 0.1.2
 
   # Common dependencies - can use ^ or ~

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ catalog:
   '@platforma-sdk/ui-vue': 1.77.4
   '@platforma-sdk/tengo-builder': 3.0.0
   '@platforma-sdk/package-builder': 3.12.0
-  '@platforma-sdk/block-tools': 2.8.0
+  '@platforma-sdk/block-tools': 2.8.2
   '@platforma-sdk/eslint-config': 1.2.0
   '@platforma-sdk/test': 1.77.4
   '@milaboratories/helpers': 1.14.2

--- a/ui/src/app.ts
+++ b/ui/src/app.ts
@@ -1,4 +1,4 @@
-import { getDefaultBlockLabel, platforma } from '@platforma-open/milaboratories.top-antibodies.model';
+import { getDefaultBlockLabel, getInputAnchorRef, platforma } from '@platforma-open/milaboratories.top-antibodies.model';
 import { plRefsEqual } from '@platforma-sdk/model';
 import { defineAppV3 } from '@platforma-sdk/ui-vue';
 import { watchEffect } from 'vue';
@@ -31,10 +31,11 @@ type AppModel = ReturnType<typeof useApp>['model'];
 
 function syncDefaultBlockLabel(model: AppModel) {
   watchEffect(() => {
-    const datasetLabel = model.data.inputAnchor
-      ? model.outputs.inputOptions
-        ?.find((option) => plRefsEqual(option.ref, model.data.inputAnchor!))
-        ?.label
+    const anchorRef = getInputAnchorRef(model.data);
+    const datasetLabel = anchorRef
+      ? model.outputs.datasetOptions
+        ?.find((option) => plRefsEqual(option.primary.ref, anchorRef))
+        ?.primary.label
       : undefined;
 
     model.data.defaultBlockLabel = getDefaultBlockLabel({

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { PlMultiSequenceAlignment } from '@milaboratories/multi-sequence-alignment';
 import strings from '@milaboratories/strings';
+import { getInputAnchorRef } from '@platforma-open/milaboratories.top-antibodies.model';
 import type { PlRef, PlSelectionModel } from '@platforma-sdk/model';
 import { createPlDataTableStateV2 } from '@platforma-sdk/model';
 import {
@@ -9,8 +10,8 @@ import {
   PlBlockPage,
   PlBtnGhost,
   PlCheckbox,
+  PlDatasetSelector,
   PlDropdown,
-  PlDropdownRef,
   PlIcon16,
   PlNumberField,
   PlRow,
@@ -28,7 +29,12 @@ import RankList from './components/RankList.vue';
 
 const app = useApp();
 
-const settingsOpen = ref(app.model.data.inputAnchor === undefined);
+// Current primary anchor PlRef extracted from the DatasetSelection. Watchers
+// and downstream lookups all key off this — `data.input` is the opaque payload,
+// but the existing block logic still thinks in terms of "the anchor".
+const inputAnchorRef = computed(() => getInputAnchorRef(app.model.data));
+
+const settingsOpen = ref(inputAnchorRef.value === undefined);
 const multipleSequenceAlignmentOpen = ref(false);
 
 // Watch for when the workflow starts running and close settings
@@ -99,7 +105,7 @@ const selectedClusterColumnValue = computed<string | undefined>({
 
 // Clear diversificationColumn when inputAnchor changes (old value is invalid for new dataset)
 watch(
-  () => app.model.data.inputAnchor,
+  inputAnchorRef,
   (newAnchor, oldAnchor) => {
     if (oldAnchor && newAnchor && JSON.stringify(oldAnchor) !== JSON.stringify(newAnchor)) {
       app.model.data.diversificationColumn = undefined;
@@ -146,7 +152,7 @@ const selectedPresetValue = computed<string>({
 
 // Reset preset when inputAnchor or modality changes (clears stale presets when
 watch(
-  [() => app.model.data.inputAnchor, () => app.model.outputs.modality],
+  [inputAnchorRef, () => app.model.outputs.modality],
   () => {
     app.model.data.preset = undefined;
   },
@@ -186,7 +192,7 @@ watch(() => app.model.data.topClonotypes, (newVal) => {
 });
 
 // Reset table state when dataset or Kabat toggle changes to re-apply defaults (like optional visibility)
-watch(() => [app.model.data.inputAnchor, app.model.data.kabatNumbering], () => {
+watch(() => [inputAnchorRef.value, app.model.data.kabatNumbering], () => {
   app.model.data.tableState = createPlDataTableStateV2();
 });
 </script>
@@ -226,10 +232,10 @@ watch(() => [app.model.data.inputAnchor, app.model.data.kabatNumbering], () => {
     <PlSlideModal v-model="settingsOpen" :close-on-outside-click="true">
       <template #title>Settings</template>
 
-      <!-- First element: Select dataset -->
-      <PlDropdownRef
-        v-model="app.model.data.inputAnchor"
-        :options="app.model.outputs.inputOptions"
+      <!-- First element: Select dataset (with optional filter dropdown) -->
+      <PlDatasetSelector
+        v-model="app.model.data.input"
+        :options="app.model.outputs.datasetOptions"
         :style="{ width: '320px' }"
         label="Select dataset"
         clearable

--- a/ui/src/pages/components/FilterList.vue
+++ b/ui/src/pages/components/FilterList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { DiscreteFilter, FilterUI, PlTableFilter, ScopedColumnId } from '@platforma-open/milaboratories.top-antibodies.model';
+import { getInputAnchorRef } from '@platforma-open/milaboratories.top-antibodies.model';
 import { PlBtnSecondary, PlElementList, PlIcon16, PlRow, PlTooltip } from '@platforma-sdk/ui-vue';
 import { ref } from 'vue';
 import { useApp } from '../../app';
@@ -60,7 +61,7 @@ const resetToDefaults = () => {
 
 // Use shared anchor sync logic
 useAnchorSyncedDefaults({
-  getAnchor: () => app.model.data.inputAnchor,
+  getAnchor: () => getInputAnchorRef(app.model.data),
   getConfig: () => app.model.outputs.filterConfig,
   clearState: () => {
     app.model.data.filters = [];

--- a/ui/src/pages/components/RankList.vue
+++ b/ui/src/pages/components/RankList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { ScopedColumnId } from '@platforma-open/milaboratories.top-antibodies.model';
+import { getInputAnchorRef } from '@platforma-open/milaboratories.top-antibodies.model';
 import { PlBtnSecondary, PlElementList, PlIcon16, PlRow, PlTooltip } from '@platforma-sdk/ui-vue';
 import { ref } from 'vue';
 import { useApp } from '../../app';
@@ -60,7 +61,7 @@ const resetToDefaults = () => {
 
 // Use shared anchor sync logic
 useAnchorSyncedDefaults({
-  getAnchor: () => app.model.data.inputAnchor,
+  getAnchor: () => getInputAnchorRef(app.model.data),
   getConfig: () => app.model.outputs.rankingConfig,
   clearState: () => {
     app.model.data.rankingOrder = [];

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -7,6 +7,7 @@ pframes := import("@platforma-sdk/workflow-tengo:pframes")
 slices := import("@platforma-sdk/workflow-tengo:slices")
 render := import("@platforma-sdk/workflow-tengo:render")
 pSpec := import("@platforma-sdk/workflow-tengo:pframes.spec")
+smart := import("@platforma-sdk/workflow-tengo:smart")
 ll := import("@platforma-sdk/workflow-tengo:ll")
 kabatConv := import(":pf-kabat-conv")
 
@@ -156,9 +157,14 @@ wf.prepare(func(args){
 })
 
 wf.body(func(args) {
-	// output containers 
+	// output containers
 	outputs := {}
     exports := {}
+
+    // Expose this block's own id so the model can drop self-produced filter
+    // entries from the dataset selector — without this the just-finished
+    // sampled subset shows up as a filter option on the next configuration.
+    outputs["selfBlockId"] = smart.createJsonResource(wf.getBlockId())
 
     if !is_undefined(args.inputAnchor) {
         // Input arguments

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -25,8 +25,15 @@ wf.prepare(func(args){
 	// We need a table with cluster ID (optional) | clonotype id | selected ranking columns
     bundleBuilder := wf.createPBundleBuilder()
     bundleBuilder.ignoreMissingDomains() // to make query work for both bulk and single cell data
-    bundleBuilder.addAnchor("main", args.inputAnchor) 
-    
+    bundleBuilder.addAnchor("main", args.inputAnchor)
+
+    // Optional primary filter from PlDatasetSelector — inner-joined into the
+    // clone table below so the filter narrows every downstream stage
+    // (finalClonotypes, spectratype, Kabat, etc.).
+    if !is_undefined(args.inputFilter) {
+        bundleBuilder.addRef(args.inputFilter)
+    }
+
     validRanks := false
     if len(args.rankingOrder) > 0 {
         for col in args.rankingOrder {
@@ -164,8 +171,14 @@ wf.body(func(args) {
 	    isPeptide := datasetSpec.axesSpec[1].name == "pl7.app/variantKey"
     
         ////////// Clonotype Filtering //////////
-        // Initialize and build clone table with all columns
-        tableInit := utils.initializeCloneTable(pframes, columns, args, datasetSpec)
+        // Initialize and build clone table with all columns. When the user
+        // picked an optional primary filter in PlDatasetSelector, fetch the
+        // resolved column so initializeCloneTable can inner-join it.
+        inputFilterColumn := undefined
+        if !is_undefined(args.inputFilter) {
+            inputFilterColumn = columns.getColumn(args.inputFilter)
+        }
+        tableInit := utils.initializeCloneTable(pframes, columns, args, datasetSpec, inputFilterColumn)
         cloneTable := tableInit.cloneTable
         filterMap := tableInit.filterMap
         rankingMap := tableInit.rankingMap

--- a/workflow/src/utils.lib.tengo
+++ b/workflow/src/utils.lib.tengo
@@ -232,27 +232,39 @@ resolveClusterColumnHeader := func(args, columns, sortedLinkers) {
 /**
  * Initializes and builds complete clone table with all columns.
  * Handles filters, ranking columns, linkers, cluster sizes, and fallback columns.
- * 
+ *
  * @param pframes - PFrames import
  * @param columns - PBundle containing all columns
  * @param args - Arguments containing filters, rankingOrder, diversificationColumn
  * @param datasetSpec - Dataset specification with axes
+ * @param inputFilterColumn - Optional resolved column from the primary filter
+ *        (PlDatasetSelector). Added with an inner join so missing keys are
+ *        dropped from the clone table — narrows every downstream stage.
  * @return Map with keys: cloneTable, filterMap, rankingMap, sortedLinkers, clusterColumnHeader, addedCols
  */
-initializeCloneTable := func(pframes, columns, args, datasetSpec) {
+initializeCloneTable := func(pframes, columns, args, datasetSpec, inputFilterColumn) {
     // Build clonotype table
     cloneTable := pframes.parquetFileBuilder()
     cloneTable.setAxisHeader(datasetSpec.axesSpec[1], "clonotypeKey")
-    
+
     // Build linker list in SAME ORDER as model
     sortedLinkers := buildSortedLinkers(columns, datasetSpec)
-    
+
     // Add Filters to table
     addedAxes := []
     filterMap := {}
     rankingMap := {}
     addedCols := false
-    
+
+    // Apply the optional primary filter from PlDatasetSelector first. The
+    // builder's inner-join keeps the rows where every added column has a
+    // value, so once this column is present rows missing from the filter are
+    // dropped from the entire pipeline.
+    if !is_undefined(inputFilterColumn) {
+        cloneTable.add(inputFilterColumn, {header: "primary_filter"})
+        addedCols = true
+    }
+
     if len(args.filters) > 0 {
         for i, filter in args.filters {
             // we check for value presence and for actual pcolumn (cases where upstream block is deleted)


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the plain `PlDropdownRef` dataset selector with `PlDatasetSelector`, introducing an optional secondary filter column alongside the primary anchor. The old `inputAnchor: PlRef` field is replaced by `input: DatasetSelection` in `BlockData`, with a migration step and a pair of helper functions (`getInputAnchorRef`, `getInputFilterRef`) to unpack it. The Tengo workflow adds the selected filter column to the `cloneTable` via an inner-join, narrowing every downstream stage (final clonotypes, spectratype, Kabat).

- **Model & types**: `BlockData_Ver_2026_05_08` is now a named intermediate type so the new migration (`Ver_2026_05_21`) can correctly strip `inputAnchor` and produce `input: DatasetSelection`; `BlockArgs` gains an `inputFilter?: PlRef` field passed through to the workflow.
- **UI**: All Vue components that previously read `data.inputAnchor` directly now call `getInputAnchorRef(data)`, with `MainPage.vue` also exposing an `inputAnchorRef` computed ref; the `datasetOptions` output replaces `inputOptions` with `buildDatasetOptions` using a typed primary predicate.
- **Workflow**: `initializeCloneTable` receives the resolved filter column and prepends it to the `parquetFileBuilder` before user-configured filters, relying on the builder's inner-join semantics to drop non-matching rows from all subsequent stages.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The migration chain, type changes, and helper-function refactor are consistent and well-contained; the main workflow path works correctly for the new filter feature.

The model, migration, and UI layers are cleanly updated with no clear logic gaps. Two open questions keep the score below the maximum: the primary_filter column carries raw values into the intermediate parquet file and may leak into downstream outputs depending on how filterAndSampleTpl handles unknown headers; and the table-state reset watch now silently skips filter-only changes, which may or may not match the intended UX contract. Neither is a definite breakage but both are worth confirming before shipping.

workflow/src/utils.lib.tengo and the filterAndSampleTpl sub-template (not in this diff) — confirm whether the primary_filter column is stripped or forwarded in the final P-frame outputs. ui/src/pages/MainPage.vue line 619 — confirm whether a filter-only change should also reset table state.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| model/src/types.ts | Introduces BlockData_Ver_2026_05_08 as a named type and redefines BlockData to Omit inputAnchor, adding the new input: DatasetSelection field; BlockArgs gains inputFilter. |
| model/src/dataModel.ts | Adds Ver_2026_05_21 migration that strips inputAnchor and recreates it as input: DatasetSelection via createDatasetSelection/createPrimaryRef; correctly types Ver_2026_05_08 migration. |
| model/src/util.ts | Adds getInputAnchorRef (reads input.primary.column) and getInputFilterRef (reads input.primary.filter) as clean accessors for the new DatasetSelection shape. |
| model/src/index.ts | Replaces inputOptions/PlDropdownRef pattern with datasetOptions/buildDatasetOptions; all ctx.data.inputAnchor reads replaced by getInputAnchorRef(ctx.data); exports the two new helpers. |
| ui/src/pages/MainPage.vue | Introduces inputAnchorRef computed, replaces PlDropdownRef with PlDatasetSelector bound to data.input; watchers updated consistently. |
| workflow/src/utils.lib.tengo | initializeCloneTable gains inputFilterColumn param; when present, adds it with header primary_filter before user filters, relying on inner-join semantics to narrow rows. |
| workflow/src/main.tpl.tengo | Fetches inputFilterColumn from columns when args.inputFilter is set and passes it to initializeCloneTable; also addRef in prepare so the column is resolved in the bundle. |
| ui/src/app.ts | syncDefaultBlockLabel updated to use datasetOptions and getInputAnchorRef; logic unchanged otherwise. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as PlDatasetSelector (UI)
    participant Model as BlockModel
    participant Args as BlockArgs (workflow input)
    participant WF as Tengo Workflow
    participant CT as parquetFileBuilder (cloneTable)

    UI->>Model: "data.input = DatasetSelection"
    Model->>Model: getInputAnchorRef → input.primary.column
    Model->>Model: getInputFilterRef → input.primary.filter
    Model->>Args: "{ inputAnchor, inputFilter? }"
    Args->>WF: prepare() addAnchor(main) + addRef(inputFilter)
    WF->>WF: body() resolve inputFilterColumn
    WF->>CT: initializeCloneTable(..., inputFilterColumn)
    CT->>CT: add(inputFilterColumn, header:primary_filter)
    CT->>CT: add Filter_0..N columns
    CT->>CT: add Col_0..N ranking columns
    CT-->>WF: cloneTable + filterMap + rankingMap
    WF->>WF: filterAndSampleTpl → finalClonotypes
    WF-->>Model: sampledRows, selectionStagePf, exports
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ui/src/pages/MainPage.vue`, line 619-622 ([link](https://github.com/platforma-open/antibody-tcr-lead-selection/blob/011ae8ea2ab01b2b40ddca587e2c4921ad03b5fb/ui/src/pages/MainPage.vue#L619-L622)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Table-state reset does not fire when filter changes without anchor change**

   The watch source array uses `inputAnchorRef.value` (the anchor ref only), so if the user picks a new filter column while keeping the same primary anchor, the table state is never reset. For filter-only and ranking-only watches the same anchor-scoping is intentional, but the table-state reset was added specifically to re-apply column visibility defaults. A changed filter still alters which rows are shown and might justify resetting the table state (e.g. to reapply optional-column visibility defaults for the narrowed dataset). If filter changes are intentionally excluded from table resets, a comment here would clarify the decision.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: ui/src/pages/MainPage.vue
   Line: 619-622

   Comment:
   **Table-state reset does not fire when filter changes without anchor change**

   The watch source array uses `inputAnchorRef.value` (the anchor ref only), so if the user picks a new filter column while keeping the same primary anchor, the table state is never reset. For filter-only and ranking-only watches the same anchor-scoping is intentional, but the table-state reset was added specifically to re-apply column visibility defaults. A changed filter still alters which rows are shown and might justify resetting the table state (e.g. to reapply optional-column visibility defaults for the narrowed dataset). If filter changes are intentionally excluded from table resets, a comment here would clarify the decision.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
workflow/src/utils.lib.tengo:263-266
**`primary_filter` column values may surface in downstream output data**

The filter column is added to the parquet file with header `"primary_filter"` and its raw values are included in the file passed to `filterAndSampleTpl`. The inner-join correctly narrows the row set, but because the column carries actual data (e.g. booleans, string labels, or numeric scores from the upstream block), any downstream stage that passes through all parquet columns without an explicit allowlist would expose a `primary_filter` column in user-visible output tables or export files. If `filterAndSampleTpl` does not strip unknown headers from its output P-frames, this stale data column would appear alongside real ranking/filter columns in the final results.

### Issue 2 of 2
ui/src/pages/MainPage.vue:619-622
**Table-state reset does not fire when filter changes without anchor change**

The watch source array uses `inputAnchorRef.value` (the anchor ref only), so if the user picks a new filter column while keeping the same primary anchor, the table state is never reset. For filter-only and ranking-only watches the same anchor-scoping is intentional, but the table-state reset was added specifically to re-apply column visibility defaults. A changed filter still alters which rows are shown and might justify resetting the table state (e.g. to reapply optional-column visibility defaults for the narrowed dataset). If filter changes are intentionally excluded from table resets, a comment here would clarify the decision.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["SDK Update"](https://github.com/platforma-open/antibody-tcr-lead-selection/commit/011ae8ea2ab01b2b40ddca587e2c4921ad03b5fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34119079)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->