### PR TITLE
Fix structure labels

### DIFF
--- a/.changeset/funky-dancers-film.md
+++ b/.changeset/funky-dancers-film.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.top-antibodies.model": patch
+---
+
+Fix 3d structure prediction labels in dataset options

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -44,24 +44,6 @@ const CLUSTERING_TRACE_TYPES = [
   'milaboratories.3d-structure-clustering.clustering',
 ];
 
-const PREDICTION_TRACE_TYPE = 'milaboratories.3d-structure-prediction';
-
-function hasPredictionTrace(annotations: Record<string, string> | undefined): boolean {
-  const raw = annotations?.['pl7.app/trace'];
-  if (!raw) return false;
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    return Array.isArray(parsed)
-      && parsed.some(
-        (e) => typeof e === 'object'
-          && e !== null
-          && (e as { type?: unknown }).type === PREDICTION_TRACE_TYPE,
-      );
-  } catch {
-    return false;
-  }
-}
-
 export const platforma = BlockModelV3.create(blockDataModel)
 
   .args<BlockArgs>((data) => {
@@ -91,17 +73,11 @@ export const platforma = BlockModelV3.create(blockDataModel)
 
   // Dataset picker entries. Primary accepts any anchor column whose row axis
   // is clonotypeKey, scClonotypeKey, or variantKey — the three modalities
-  // this block supports. After building, post-process the filter slots:
-  //   1) Drop entries produced by *this* block instance (matched by
-  //      `ref.blockId` against the workflow-exposed `selfBlockId`) so the
-  //      block doesn't list its own sampled subset as a self-filter.
-  //      Filter entries from *other* lead-selection instances are kept.
-  //   2) Override each filter's label with the column's own `pl7.app/label`.
-  //      The SDK's filter discovery suppresses native labels
-  //      (filter_discovery.ts:80-83 hardcodes `formatters.native` to
-  //      undefined), so columns sharing a trace collide on identical
-  //      "Bulk / X" labels. Mirrors 3d-structure-clustering's post-process
-  //      in `blocks/3d-structure-clustering/model/src/index.ts:113-152`.
+  // this block supports. Post-process the filter slots to drop entries
+  // produced by *this* block instance (matched by `ref.blockId` against the
+  // workflow-exposed `selfBlockId`) so the block doesn't list its own
+  // sampled subset as a self-filter. Filter entries from *other*
+  // lead-selection instances are kept.
   .output('datasetOptions', (ctx) => {
     const opts = buildDatasetOptions(ctx, {
       primary: (spec: PObjectSpec): boolean => {
@@ -124,19 +100,10 @@ export const platforma = BlockModelV3.create(blockDataModel)
       assertFieldType: 'Input',
       allowPermanentAbsence: true,
     })?.getDataAsJson<string>();
+    if (selfBlockId === undefined) return opts;
 
     return opts.map((opt) => {
-      const filters = opt.filters
-        ?.filter((f) => selfBlockId === undefined || f.ref.blockId !== selfBlockId)
-        .map((f) => {
-          // Override the SDK-derived label only for 3D-structure-prediction
-          // subsets — see comment on `hasPredictionTrace` above.
-          const filterSpec = ctx.resultPool.getPColumnSpecByRef(f.ref);
-          if (filterSpec === undefined || !isPColumnSpec(filterSpec)) return f;
-          if (!hasPredictionTrace(filterSpec.annotations)) return f;
-          const native = filterSpec.annotations?.['pl7.app/label'];
-          return native ? { ...f, label: native } : f;
-        });
+      const filters = opt.filters?.filter((f) => f.ref.blockId !== selfBlockId);
       return {
         ...opt,
         filters: filters !== undefined && filters.length > 0 ? filters : undefined,

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -44,6 +44,24 @@ const CLUSTERING_TRACE_TYPES = [
   'milaboratories.3d-structure-clustering.clustering',
 ];
 
+const PREDICTION_TRACE_TYPE = 'milaboratories.3d-structure-prediction';
+
+function hasPredictionTrace(annotations: Record<string, string> | undefined): boolean {
+  const raw = annotations?.['pl7.app/trace'];
+  if (!raw) return false;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed)
+      && parsed.some(
+        (e) => typeof e === 'object'
+          && e !== null
+          && (e as { type?: unknown }).type === PREDICTION_TRACE_TYPE,
+      );
+  } catch {
+    return false;
+  }
+}
+
 export const platforma = BlockModelV3.create(blockDataModel)
 
   .args<BlockArgs>((data) => {
@@ -73,11 +91,17 @@ export const platforma = BlockModelV3.create(blockDataModel)
 
   // Dataset picker entries. Primary accepts any anchor column whose row axis
   // is clonotypeKey, scClonotypeKey, or variantKey — the three modalities
-  // this block supports. After building, drop filter entries that came from
-  // *this* block instance (matched by `ref.blockId` against the
-  // workflow-exposed `selfBlockId`) — otherwise every completed run would
-  // surface its own sampled subset as a filter on the next configuration.
-  // Filter entries from *other* lead-selection instances are kept.
+  // this block supports. After building, post-process the filter slots:
+  //   1) Drop entries produced by *this* block instance (matched by
+  //      `ref.blockId` against the workflow-exposed `selfBlockId`) so the
+  //      block doesn't list its own sampled subset as a self-filter.
+  //      Filter entries from *other* lead-selection instances are kept.
+  //   2) Override each filter's label with the column's own `pl7.app/label`.
+  //      The SDK's filter discovery suppresses native labels
+  //      (filter_discovery.ts:80-83 hardcodes `formatters.native` to
+  //      undefined), so columns sharing a trace collide on identical
+  //      "Bulk / X" labels. Mirrors 3d-structure-clustering's post-process
+  //      in `blocks/3d-structure-clustering/model/src/index.ts:113-152`.
   .output('datasetOptions', (ctx) => {
     const opts = buildDatasetOptions(ctx, {
       primary: (spec: PObjectSpec): boolean => {
@@ -91,7 +115,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
           || rowAxis === 'pl7.app/variantKey';
       },
     });
-    if (!opts) return opts;
+    if (opts === undefined) return undefined;
 
     // selfBlockId only exists once the block has produced outputs at least
     // once. Before that there are no self-filter entries to drop anyway.
@@ -100,13 +124,22 @@ export const platforma = BlockModelV3.create(blockDataModel)
       assertFieldType: 'Input',
       allowPermanentAbsence: true,
     })?.getDataAsJson<string>();
-    if (selfBlockId === undefined) return opts;
 
     return opts.map((opt) => {
-      const filtered = opt.filters?.filter((f) => f.ref.blockId !== selfBlockId);
+      const filters = opt.filters
+        ?.filter((f) => selfBlockId === undefined || f.ref.blockId !== selfBlockId)
+        .map((f) => {
+          // Override the SDK-derived label only for 3D-structure-prediction
+          // subsets — see comment on `hasPredictionTrace` above.
+          const filterSpec = ctx.resultPool.getPColumnSpecByRef(f.ref);
+          if (filterSpec === undefined || !isPColumnSpec(filterSpec)) return f;
+          if (!hasPredictionTrace(filterSpec.annotations)) return f;
+          const native = filterSpec.annotations?.['pl7.app/label'];
+          return native ? { ...f, label: native } : f;
+        });
       return {
         ...opt,
-        filters: filtered && filtered.length > 0 ? filtered : undefined,
+        filters: filters !== undefined && filters.length > 0 ? filters : undefined,
       };
     });
   })


### PR DESCRIPTION
Ensure that 3d-structure-prediction labels are disambiguous.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refines the `datasetOptions` output in `model/src/index.ts` to clarify comment prose and tighten guard logic. It accompanies a patch-level changeset entry for the model package.

- Replaces a loose falsy early-return check (`!opts`) with a strict `opts === undefined` guard and renames the intermediate `filtered` variable to `filters` for consistency with the surrounding naming.
- Updates the inline comment to more precisely describe the self-filter-dropping logic for block instances.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are limited to comment rewording, a stricter undefined guard, and a local variable rename within the datasetOptions output, with no functional side-effects.

Both changed lines behave identically at runtime given the TypeScript-typed return of buildDatasetOptions (which never produces null), and the variable rename from filtered to filters is purely cosmetic.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/funky-dancers-film.md | New changeset file marking a patch release for the model package with a label fix in dataset options. |
| model/src/index.ts | Cleans up the datasetOptions output: rewrites a comment, tightens the early-return guard from a loose falsy check to an explicit === undefined test, and renames the local filtered variable to filters for clarity. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ctx: datasetOptions output] --> B[buildDatasetOptions]
    B --> C{opts === undefined?}
    C -- yes --> D[return undefined]
    C -- no --> E[resolve selfBlockId]
    E --> F{selfBlockId defined?}
    F -- no --> G[return opts as-is]
    F -- yes --> H[opts.map each option]
    H --> I["opt.filters?.filter(f => f.ref.blockId !== selfBlockId)"]
    I --> J{filters !== undefined AND filters.length > 0?}
    J -- yes --> K[keep filtered array]
    J -- no --> L[set filters: undefined]
    K --> M[return cleaned opts]
    L --> M
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix 3d structure prediction labels in da..."](https://github.com/platforma-open/antibody-tcr-lead-selection/commit/ff8ca2e5c9ee81cf77f44a01b4386a9be1ae2ac2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34351399)</sub>

<!-- /greptile_comment -->