### PR TITLE
Feat: humanness score default ranking

### DIFF
--- a/.changeset/humanness-score-default-ranking.md
+++ b/.changeset/humanness-score-default-ranking.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.top-antibodies.model": patch
+---
+
+Recognize the humanization-score block's output (`pl7.app/humannessScore`) as a default ranking criterion in both the In Vivo and In Vitro presets. Discovery already picks the column up via `pl7.app/isScore=true`; this change adds it to the per-preset spec-name allowlist so it contributes to the default ranking order (ranking only — no filter cutoff). Higher = more human, ordering decreasing.

--- a/model/src/util.ts
+++ b/model/src/util.ts
@@ -79,6 +79,7 @@ export const IN_VIVO_FILTER_SPEC_NAMES = new Set([
 export const IN_VIVO_RANKING_SPEC_NAMES = new Set([
   'pl7.app/developabilityScore',
   'pl7.app/vdj/developabilityScore',
+  'pl7.app/humannessScore',
 ]);
 
 // In Vitro preset allowlists. Same intersection-with-discovery approach as
@@ -105,6 +106,7 @@ export const IN_VITRO_RANKING_SPEC_NAMES = new Set([
   'pl7.app/vdj/developabilityScore',
   'pl7.app/enrichment',
   'pl7.app/vdj/enrichment',
+  'pl7.app/humannessScore',
 ]);
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8478,7 +8478,7 @@ snapshots:
       oxlint: 1.63.0
       oxlint-plugin-eslint: 1.63.0
       rolldown: 1.0.0-rc.14
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.9.1)(rollup@4.52.5)
       typescript: 5.9.3
@@ -8519,7 +8519,7 @@ snapshots:
       oxlint: 1.63.0
       oxlint-plugin-eslint: 1.63.0
       rolldown: 1.0.0-rc.14
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.9.1)(rollup@4.52.5)
       typescript: 5.9.3
@@ -9049,7 +9049,7 @@ snapshots:
       '@milaboratories/pl-middle-layer': 1.61.7(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pl-tree': 1.12.2
       '@platforma-sdk/model': 1.77.11
-      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3(@types/node@24.9.1)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.16(@types/node@24.9.1)(lightningcss@1.32.0)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))(vite@8.0.7(@types/node@24.9.1)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))
+      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
       vitest: 4.1.3(@types/node@24.9.1)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.16(@types/node@24.9.1)(lightningcss@1.32.0)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))(vite@8.0.7(@types/node@24.9.1)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1))
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
@@ -12073,7 +12073,7 @@ snapshots:
       vite: 8.0.7(@types/node@24.9.1)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)
       vue: 3.5.25(typescript@5.6.3)
 
-  '@vitest/coverage-istanbul@4.1.3(vitest@4.1.3(@types/node@24.9.1)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.16(@types/node@24.9.1)(lightningcss@1.32.0)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))(vite@8.0.7(@types/node@24.9.1)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))':
+  '@vitest/coverage-istanbul@4.1.3(vitest@4.1.3)':
     dependencies:
       '@babel/core': 7.29.0
       '@istanbuljs/schema': 0.1.3
@@ -14177,7 +14177,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3)):
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3
@@ -14900,7 +14900,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.9.1
-      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3(@types/node@24.9.1)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.16(@types/node@24.9.1)(lightningcss@1.32.0)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))(vite@8.0.7(@types/node@24.9.1)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))
+      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `'pl7.app/humannessScore'` to the ranking allowlists for both the In Vivo and In Vitro presets, so the humanness-score block's output contributes to the default ranking order (decreasing — higher = more human) without adding a filter cutoff. The lockfile is also updated with unrelated peer-dependency resolution changes.

- `model/src/util.ts`: Adds `'pl7.app/humannessScore'` to `IN_VIVO_RANKING_SPEC_NAMES` and `IN_VITRO_RANKING_SPEC_NAMES`; the actual ranking direction (`decreasing`) comes from the column's `pl7.app/score/rankingOrder` annotation and falls back to `'decreasing'` by default, which matches the stated intent.
- `pnpm-lock.yaml`: Two peer-dependency hash changes — `vue-tsc@3.2.6` peer shifts from `typescript@5.9.3` to `typescript@5.6.3` and `@vitest/coverage-istanbul` peer key is simplified; these appear unrelated to the feature change.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the only behavioural change is two new entries in two allowlist Sets, and the fallback ranking direction matches the stated intent.

The util.ts change is minimal — two string literals added to in-memory Sets. The main open question is whether a pl7.app/vdj/humannessScore variant should also be listed, but if the block is purely post-peptide-adaptation this omission is intentional and harmless. The lockfile peer-dependency shift is a cosmetic concern that does not affect runtime logic.

A quick confirmation that no pl7.app/vdj/humannessScore spec name exists in older upstream block releases would fully close the review. The pnpm-lock.yaml DTS peer change is worth a sanity-check on the declaration-file build output.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model/src/util.ts | Adds 'pl7.app/humannessScore' to both ranking allowlists; consistent with the established pattern but omits a pl7.app/vdj/ variant present for all other multi-version scores. |
| .changeset/humanness-score-default-ranking.md | Changeset entry correctly marks this as a patch to the model package with a clear description of the change. |
| pnpm-lock.yaml | Peer dependency hash changes for rolldown-plugin-dts (vue-tsc TypeScript peer 5.9.3→5.6.3) and @vitest/coverage-istanbul appear unrelated to this feature; the TypeScript peer downgrade for the DTS plugin is worth verifying. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Discovery: all columns with pl7.app/isScore=true] --> B{Filter by preset allowlist}
    B -->|IN_VIVO_RANKING_SPEC_NAMES| C[In Vivo ranking defaults]
    B -->|IN_VITRO_RANKING_SPEC_NAMES| D[In Vitro ranking defaults]
    C --> E[developabilityScore\nvdj/developabilityScore\nhumannessScore NEW]
    D --> F[developabilityScore\nvdj/developabilityScore\nenrichment\nvdj/enrichment\nhumannessScore NEW]
    E --> G{hasInVivoScore?}
    G -->|Yes| H[Prepend IN_VIVO_SCORE_COLUMN_ID\n+ filter out mutation columns]
    G -->|No| I[Use ranking as-is]
    H --> J[Final inVivoDefaults.rankingOrder]
    I --> J
    F --> K[Final inVitroDefaults.rankingOrder]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
model/src/util.ts:82-83
**Missing `pl7.app/vdj/` prefixed variant?**

Every other score in both ranking allowlists is listed in two variants — e.g. `'pl7.app/developabilityScore'` / `'pl7.app/vdj/developabilityScore'` and `'pl7.app/enrichment'` / `'pl7.app/vdj/enrichment'` — so that projects using older (pre-peptide-adaptation) upstream blocks still get defaults. If a `pl7.app/vdj/humannessScore` spec name exists in any released version of the humanness-score block, omitting it here means those projects won't include it in the default ranking. Is `pl7.app/humannessScore` exclusively a post-peptide-adaptation name with no vdj-prefixed predecessor?

### Issue 2 of 2
pnpm-lock.yaml:8481
**Unrelated peer-dependency downgrade in lockfile**

The `rolldown-plugin-dts` snapshot key shifts from `vue-tsc@3.2.6(typescript@5.9.3)` to `vue-tsc@3.2.6(typescript@5.6.3)`. This changes which TypeScript version `vue-tsc` uses when `rolldown-plugin-dts` generates declaration files — from 5.9.3 down to 5.6.3. Similarly, `@vitest/coverage-istanbul`'s peer key is simplified. These changes appear unrelated to the humanness-score feature; if they were introduced by a bare `pnpm install` run rather than an intentional dependency update, it's worth confirming the DTS build still produces correct output under the lower TypeScript version.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update rolldown-plugin-dts and vitest/co..."](https://github.com/platforma-open/antibody-tcr-lead-selection/commit/eb3f325cc37c1156b7f2b1495d33eb017e0c49f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34561282)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->