### PR TITLE
[Draft] Migration to new column access

### DIFF
--- a/model/src/dataModel.ts
+++ b/model/src/dataModel.ts
@@ -1,5 +1,6 @@
 import {
   createDatasetSelection,
+  createGlobalPObjectId,
   createPlDataTableStateV2,
   createPrimaryRef,
   DataModelBuilder,
@@ -8,6 +9,7 @@ import type {
   BlockData,
   BlockData_Ver_2026_02_25,
   BlockData_Ver_2026_05_08,
+  BlockData_Ver_2026_05_21,
   LegacyBlockArgs,
   LegacyUiState,
 } from './types';
@@ -22,6 +24,9 @@ const defaultSelectionPlotState = (): BlockData['selectionPlotState'] => ({
 export const blockDataModel = new DataModelBuilder()
   .from<BlockData_Ver_2026_02_25>('Ver_2026_02_25')
   .upgradeLegacy<LegacyBlockArgs, LegacyUiState>(({ args, uiState }) => ({
+    // upgradeLegacy returns the v1 shape — inputAnchor / diversificationColumn
+    // are still PlRef here. The PlRef → ColumnUniversalId conversion happens in
+    // the dedicated Ver_2026_05_28 step so stored-v1 data takes the same path.
     defaultBlockLabel: args.defaultBlockLabel,
     customBlockLabel: args.customBlockLabel,
     inputAnchor: args.inputAnchor,
@@ -57,12 +62,21 @@ export const blockDataModel = new DataModelBuilder()
     ...prev,
     selectionPlotState: defaultSelectionPlotState(),
   }))
-  .migrate<BlockData>('Ver_2026_05_21', (prev) => {
+  .migrate<BlockData_Ver_2026_05_21>('Ver_2026_05_21', (prev) => {
     const { inputAnchor, ...rest } = prev;
     return {
       ...rest,
       input: inputAnchor !== undefined
         ? createDatasetSelection(createPrimaryRef(inputAnchor))
+        : undefined,
+    };
+  })
+  .migrate<BlockData>('Ver_2026_05_28', (prev) => {
+    const { diversificationColumn, ...rest } = prev;
+    return {
+      ...rest,
+      diversificationColumn: diversificationColumn !== undefined
+        ? createGlobalPObjectId(diversificationColumn.blockId, diversificationColumn.name)
         : undefined,
     };
   })

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -1,37 +1,44 @@
 import strings from '@milaboratories/strings';
 import type {
-  ColumnSource,
-  InferHrefType,
+  ColumnRecipe, InferHrefType,
   InferOutputsType,
   PColumn,
   PColumnDataUniversal,
   PColumnIdAndSpec,
   PColumnSpec,
-  PlRef,
+  PObjectId,
   PObjectSpec,
   PTableSorting,
+  RelaxedColumnSelector,
 } from '@platforma-sdk/model';
 import {
   Annotation,
-  ArrayColumnProvider,
   BlockModelV3,
   buildDatasetOptions,
-  canonicalizeJson,
+  Column,
+  ColumnsCollection,
   createPFrameForGraphs,
   createPlDataTableV3,
+  deriveColumnOptions,
   deriveLabels,
+  isColumnLazy,
   isHiddenFromGraphColumn,
   isHiddenFromUIColumn,
   isPColumnSpec,
 } from '@platforma-sdk/model';
-import { buildCollection, commonExcludeSelectors, getInputAnchorRef, getInputFilterRef, IN_VIVO_SCORE_COLUMN_ID, isClusterIdAxisName, isSelectableMatch, matchToColumnId } from './util';
+import {
+  buildCollection, getInputAnchorId, getInputFilterId,
+  IN_VIVO_SCORE_COLUMN_ID,
+  isClusterIdAxisName,
+  recipeToColumnId,
+} from './util';
 import { convertFilterUI, convertRankingOrderUI } from './converters';
 import { blockDataModel } from './dataModel';
 import type { BlockArgs } from './types';
 
 export * from './types';
 export * from './converters';
-export { getDefaultBlockLabel, getInputAnchorRef, getInputFilterRef } from './util';
+export { getDefaultBlockLabel, getInputAnchorId, getInputAnchorRef, getInputFilterId } from './util';
 export { blockDataModel } from './dataModel';
 export type Href = InferHrefType<typeof platforma>;
 export type BlockOutputs = InferOutputsType<typeof platforma>;
@@ -44,10 +51,53 @@ const CLUSTERING_TRACE_TYPES = [
   'milaboratories.3d-structure-clustering.clustering',
 ];
 
+/** Narrow a recipe list to leaves and materialise them for `createPFrameForGraphs`,
+ *  which still requires `PColumn<PColumnDataUniversal>[]`. Returns `undefined` if
+ *  any leaf's data is still resolving — caller should treat as "not ready". */
+function recipesToPColumns(
+  recipes: ColumnRecipe[],
+): PColumn<PColumnDataUniversal>[] | undefined {
+  const leaves = recipes.filter(isColumnLazy);
+  const out: PColumn<PColumnDataUniversal>[] = [];
+  for (const c of leaves) {
+    const data = c.getData();
+    if (data === undefined) return undefined;
+    out.push({ id: c.id, spec: c.getSpec(), data });
+  }
+  return out;
+}
+
+/** Build a `RelaxedColumnSelector[]` matching the spec signatures (name +
+ *  domain) of recipes whose id appears in `targetIds`. This lifts the legacy
+ *  lambda-based isFilterOrRank predicate into selector form so it can drive
+ *  `displayOptions.ordering[].match` / `visibility[].match`, which the V3 API
+ *  types as `ColumnSelector`, not `(spec) => boolean`. */
+function filterRankSelectors(
+  allMatches: ColumnRecipe[],
+  targetIds: Set<string>,
+): RelaxedColumnSelector[] {
+  if (targetIds.size === 0) return [];
+  const seen = new Set<string>();
+  const out: RelaxedColumnSelector[] = [];
+  for (const recipe of allMatches) {
+    if (!targetIds.has(recipe.id as string)) continue;
+    const spec = recipe.getSpec();
+    const key = JSON.stringify({ name: spec.name, domain: spec.domain ?? null });
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const selector: RelaxedColumnSelector = { name: [{ type: 'exact', value: spec.name }] };
+    if (spec.domain && Object.keys(spec.domain).length > 0) {
+      selector.domain = spec.domain;
+    }
+    out.push(selector);
+  }
+  return out;
+}
+
 export const platforma = BlockModelV3.create(blockDataModel)
 
   .args<BlockArgs>((data) => {
-    const inputAnchor = getInputAnchorRef(data);
+    const inputAnchor = getInputAnchorId(data);
     if (inputAnchor === undefined) throw new Error('No input anchor');
     if (data.topClonotypes === undefined) throw new Error('No top clonotypes');
 
@@ -62,7 +112,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
       defaultBlockLabel: data.defaultBlockLabel,
       customBlockLabel: data.customBlockLabel,
       inputAnchor,
-      inputFilter: getInputFilterRef(data),
+      inputFilter: getInputFilterId(data),
       topClonotypes: data.topClonotypes,
       rankingOrder,
       filters,
@@ -112,40 +162,33 @@ export const platforma = BlockModelV3.create(blockDataModel)
   })
 
   .output('inputAnchorSpec', (ctx) => {
-    const ref = getInputAnchorRef(ctx.data);
-    if (ref === undefined) return undefined;
-    return ctx.resultPool.getPColumnSpecByRef(ref);
+    const id = getInputAnchorId(ctx.data);
+    if (id === undefined) return undefined;
+    return Column(id)?.getSpec();
   }, { retentive: true })
 
   .output('modality', (ctx) => {
-    const ref = getInputAnchorRef(ctx.data);
-    if (ref === undefined) return undefined;
-    const spec = ctx.resultPool.getPColumnSpecByRef(ref);
+    const id = getInputAnchorId(ctx.data);
+    if (id === undefined) return undefined;
+    const spec = Column(id)?.getSpec();
     if (!spec) return undefined;
     return spec.axesSpec[1]?.name === 'pl7.app/variantKey' ? 'peptide' : 'antibody_tcr';
   }, { retentive: true })
 
   // Combined filter config - options and defaults together for atomic updates
   .output('filterConfig', (ctx) => {
-    const inputAnchor = getInputAnchorRef(ctx.data);
-    const result = buildCollection(ctx, inputAnchor);
-    if (!result) return undefined;
+    const anchorId = getInputAnchorId(ctx.data);
+    const result = buildCollection(ctx, anchorId);
+    if (!result || anchorId === undefined) return undefined;
 
-    const filterableMatches = result.collection.findColumns({
-      mode: 'enrichment',
-      exclude: commonExcludeSelectors,
-    }).filter((m) => isSelectableMatch(m, result.sampleAxisName));
-
-    // deriveLabels replaces getDisambiguatedOptions
     const labeled = deriveLabels(
-      filterableMatches,
-      (m) => m.column.spec,
+      result.meta.allMatches,
+      (c) => c.getSpec(),
       { includeNativeLabel: true },
     );
     const options = labeled.map(({ value, label }) => ({
       label,
-      value: matchToColumnId(value, inputAnchor!),
-      column: value.column,
+      value: recipeToColumnId(value, anchorId),
     }));
 
     return {
@@ -159,34 +202,29 @@ export const platforma = BlockModelV3.create(blockDataModel)
 
   // Combined ranking config - options and defaults together for atomic updates
   .output('rankingConfig', (ctx) => {
-    const inputAnchor = getInputAnchorRef(ctx.data);
-    const result = buildCollection(ctx, inputAnchor);
-    if (!result) return undefined;
+    const anchorId = getInputAnchorId(ctx.data);
+    const result = buildCollection(ctx, anchorId);
+    if (!result || anchorId === undefined) return undefined;
 
-    const rankableMatches = result.collection.findColumns({
-      mode: 'enrichment',
-      exclude: commonExcludeSelectors,
-    }).filter((m) =>
-      isSelectableMatch(m, result.sampleAxisName)
-      && m.column.spec.valueType !== 'String',
+    const rankable = result.meta.allMatches.filter(
+      (c) => c.getSpec().valueType !== 'String',
     );
 
     const labeled = deriveLabels(
-      rankableMatches,
-      (m) => m.column.spec,
+      rankable,
+      (c) => c.getSpec(),
       { includeNativeLabel: true },
     );
     const options = labeled.map(({ value, label }) => ({
       label,
-      value: matchToColumnId(value, inputAnchor!),
+      value: recipeToColumnId(value, anchorId),
     }));
 
-    // Add synthetic In Vivo Score option when mutation columns are present
     if (result.meta.hasInVivoScore) {
       options.unshift({
         label: 'In Vivo Score',
         value: {
-          anchorRef: inputAnchor!,
+          anchorRef: anchorId,
           anchorName: 'main',
           column: IN_VIVO_SCORE_COLUMN_ID,
         },
@@ -203,7 +241,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
   }, { retentive: true })
 
   .output('presetConfig', (ctx) => {
-    const result = buildCollection(ctx, getInputAnchorRef(ctx.data));
+    const result = buildCollection(ctx, getInputAnchorId(ctx.data));
     if (!result) return undefined;
 
     return {
@@ -214,144 +252,180 @@ export const platforma = BlockModelV3.create(blockDataModel)
   }, { retentive: true })
 
   .outputWithStatus('pf', (ctx) => {
-    const anchor = getInputAnchorRef(ctx.data);
-    if (!anchor) return undefined;
+    const anchorId = getInputAnchorId(ctx.data);
+    if (anchorId === undefined) return undefined;
 
-    const result = buildCollection(ctx, anchor);
-    if (!result) return undefined;
+    const anchorSpec = Column(anchorId)?.getSpec();
+    if (!anchorSpec) return undefined;
+
+    const anchorClonotypeAxisName = anchorSpec.axesSpec[1]?.name;
+    if (!anchorClonotypeAxisName) return undefined;
+    const sampleAxisName = anchorSpec.axesSpec[0].name;
 
     // Restrict MSA to columns sharing the input-anchor clonotype axis (main
     // dataset only). Cross-axis SC columns are excluded so PFrame never has
-    // to join disjoint axes for MSA. Also drop per-sample columns (axis set
+    // to join disjoint axes for MSA. Drop per-sample columns (axis set
     // contains sampleAxis) — they'd duplicate rows in the alignment.
-    const anchorClonotypeAxisName = ctx.resultPool.getPColumnSpecByRef(anchor)
-      ?.axesSpec[1]?.name;
-    if (!anchorClonotypeAxisName) return undefined;
+    const msaRecipes = ColumnsCollection(['result_pool'])
+      .discover({
+        anchors: { main: anchorSpec },
+        mode: 'enrichment',
+        exclude: [{ annotations: { 'pl7.app/isLinkerColumn': 'true' } }],
+      })
+      .filter({
+        include: {
+          axes: [{ name: [{ type: 'exact', value: anchorClonotypeAxisName }] }],
+          partialAxesMatch: true,
+        },
+        exclude: {
+          axes: [{ name: [{ type: 'exact', value: sampleAxisName }] }],
+          partialAxesMatch: true,
+        },
+      })
+      .getColumns()
+      .filter((c) => {
+        const spec = c.getSpec();
+        return !isHiddenFromUIColumn(spec) && !isHiddenFromGraphColumn(spec);
+      });
 
-    const msaMatches = result.collection.findColumns({
-      mode: 'enrichment',
-      exclude: [
-        { annotations: { 'pl7.app/isLinkerColumn': 'true' } },
-      ],
-    }).filter((m) =>
-      !isHiddenFromUIColumn(m.column.spec)
-      && !isHiddenFromGraphColumn(m.column.spec)
-      && m.column.spec.axesSpec.some((a) => a.name === anchorClonotypeAxisName)
-      && !m.column.spec.axesSpec.some((a) => a.name === result.sampleAxisName),
-    );
-
-    const pCols: PColumn<PColumnDataUniversal>[] = [];
-    for (const m of msaMatches) {
-      if (!m.column.data) continue;
-      const data = m.column.data.get();
-      if (!data) return undefined;
-      pCols.push({ id: m.column.id, spec: m.column.spec, data });
-    }
-    return ctx.createPFrame(pCols);
+    return ctx.createPFrame(msaRecipes.map((c) => c.id));
   })
 
   // Use the cdr3LengthsCalculated cols
   .outputWithStatus('spectratypePf', (ctx) => {
-    const pCols = ctx.outputs?.resolve({
+    const accessor = ctx.outputs?.resolve({
       field: 'cdr3VspectratypePf',
       assertFieldType: 'Input',
       allowPermanentAbsence: true,
-    })?.getPColumns();
+    });
+    if (accessor === undefined) return undefined;
+    const pCols = recipesToPColumns(ColumnsCollection([accessor]).getColumns());
     if (pCols === undefined) return undefined;
-
     return createPFrameForGraphs(ctx, pCols);
   })
 
   // Use the cdr3LengthsCalculated cols
   .outputWithStatus('vjUsagePf', (ctx) => {
-    const pCols = ctx.outputs?.resolve({
+    const accessor = ctx.outputs?.resolve({
       field: 'vjUsagePf',
       assertFieldType: 'Input',
       allowPermanentAbsence: true,
-    })?.getPColumns();
+    });
+    if (accessor === undefined) return undefined;
+    const pCols = recipesToPColumns(ColumnsCollection([accessor]).getColumns());
     if (pCols === undefined) return undefined;
-
     return createPFrameForGraphs(ctx, pCols);
   })
 
   .outputWithStatus('selectionStagePf', (ctx) => {
-    const pCols = ctx.outputs?.resolve({
+    const accessor = ctx.outputs?.resolve({
       field: 'selectionStagePf',
       assertFieldType: 'Input',
       allowPermanentAbsence: true,
-    })?.getPColumns();
+    });
+    if (accessor === undefined) return undefined;
+    const pCols = recipesToPColumns(ColumnsCollection([accessor]).getColumns());
     if (pCols === undefined) return undefined;
-
     return createPFrameForGraphs(ctx, pCols);
   })
 
   .outputWithStatus('table', (ctx) => {
-    const anchor = ctx.activeArgs?.inputAnchor;
-    if (!anchor) return undefined;
+    const anchorId = ctx.activeArgs?.inputAnchor;
+    if (!anchorId) return undefined;
 
     // Don't render table until workflow has been executed
     if (!ctx.outputs) return undefined;
 
-    const anchorSpec = ctx.resultPool.getPColumnSpecByRef(anchor);
+    const anchorSpec = Column(anchorId)?.getSpec();
     if (!anchorSpec) return undefined;
 
-    // Resolve the sampledRows output
+    // Resolve the sampledRows output as a column source
     const sampledRowsAccessor = ctx.outputs.resolve({
       field: 'sampledRows',
       assertFieldType: 'Input',
       allowPermanentAbsence: true,
     });
+    if (sampledRowsAccessor === undefined) return undefined;
 
-    const sampledRows = sampledRowsAccessor?.getPColumns();
-    const sampledRowsAreFinal = sampledRowsAccessor?.getIsFinal() ?? false;
+    const sampledRowsCollection = ColumnsCollection([sampledRowsAccessor]);
+    const sampledRowsAreFinal = sampledRowsCollection.isFinal();
+    if (!sampledRowsAreFinal) return undefined;
 
-    // Don't render table if sampledRows don't exist or aren't finalized
-    if (sampledRows === undefined || !sampledRowsAreFinal) {
-      return undefined;
-    }
+    const leadSelectionCol = sampledRowsCollection
+      .filter({ include: { name: [{ type: 'exact', value: 'pl7.app/lead-selection' }] } })
+      .getColumns()[0];
+    if (!leadSelectionCol || !isColumnLazy(leadSelectionCol)) return undefined;
 
     // Verify sampledRows belong to current inputAnchor by checking axes
-    const samplingCol = sampledRows.find(
-      (col) => col.spec.name === 'pl7.app/lead-selection',
+    const leadSelectionSpec = leadSelectionCol.getSpec();
+    const clonotypeAxisMatches = leadSelectionSpec.axesSpec.some(
+      (axis) => JSON.stringify(axis) === JSON.stringify(anchorSpec.axesSpec[1]),
     );
-    if (samplingCol !== undefined) {
-      const clonotypeAxisMatches = samplingCol.spec.axesSpec.some(
-        (axis) => JSON.stringify(axis) === JSON.stringify(anchorSpec.axesSpec[1]),
-      );
-      if (!clonotypeAxisMatches) {
-        return undefined;
-      }
-    }
+    if (!clonotypeAxisMatches) return undefined;
 
-    const assemblingKabatAccessor = ctx.outputs?.resolve({
+    const assemblingKabatAccessor = ctx.outputs.resolve({
       field: 'assemblingKabatPf',
       assertFieldType: 'Input',
       allowPermanentAbsence: true,
     });
 
-    const resultPoolColumns = ctx.resultPool.selectColumns(
-      (spec) => (spec.valueType as string) !== 'File'
-        && !(spec.annotations?.['pl7.app/isLinkerColumn'] === 'true' && spec.axesSpec.length > 2)
-        && !spec.annotations?.[Annotation.Trace]?.includes('antibody-tcr-lead-selection'),
-    );
-    const sources: ColumnSource[] = [
-      new ArrayColumnProvider(resultPoolColumns),
-      new ArrayColumnProvider(sampledRows),
+    // Sort by ranking-order column (from sampledRows). V3 remaps the ID via originalId.
+    const rankingOrderCol = sampledRowsCollection
+      .filter({ include: { name: [{ type: 'exact', value: 'pl7.app/ranking-order' }] } })
+      .getColumns()[0];
+    const sorting: PTableSorting[] | undefined = rankingOrderCol
+      ? [{
+          column: { type: 'column', id: rankingOrderCol.id },
+          ascending: true,
+          naAndAbsentAreLeastValues: false,
+        }]
+      : undefined;
+
+    // Discover the candidate table columns. The leadSelectionCol anchor has
+    // [clonotypeKey] axis only, so the inner join core is keyed by
+    // clonotypeKey (no sampleId duplication).
+    const tableSources: Parameters<typeof ColumnsCollection>[0] = [
+      'result_pool',
+      sampledRowsAccessor,
     ];
-    if (assemblingKabatAccessor) {
-      const kabatCols = assemblingKabatAccessor.getPColumns();
-      if (kabatCols) sources.push(new ArrayColumnProvider(kabatCols));
-    }
+    if (assemblingKabatAccessor) tableSources.push(assemblingKabatAccessor);
 
-    // Use lead-selection column as anchor — it has [clonotypeKey] axis only,
-    // so the inner join core is keyed by clonotypeKey (no sampleId duplication).
-    const leadSelectionCol = sampledRows.find(
-      (col) => col.spec.name === 'pl7.app/lead-selection',
+    // Host-side exclusions: drop File-typed columns and self-trace columns
+    // (avoid cycles with previous outputs of this block).
+    const discoveredCols = ColumnsCollection(tableSources)
+      .discover({
+        anchors: { main: leadSelectionCol.getSpec() },
+        mode: 'enrichment',
+        exclude: [
+          { annotations: { [Annotation.Trace]: '.*antibody-tcr-lead-selection.*' } },
+        ],
+      })
+      .getColumns()
+      // Sandbox-side: File valueType and the "axes.length > 2 linker" rule
+      // can't be expressed as selectors — File is not in the ColumnValueType
+      // union. Every survivor pays one getSpec round-trip.
+      .filter((c) => {
+        const spec = c.getSpec();
+        if ((spec.valueType as string) === 'File') return false;
+        return !(spec.annotations?.['pl7.app/isLinkerColumn'] === 'true' && spec.axesSpec.length > 2);
+      });
+
+    // Primary must be leaves only — multi-axis Discovered hits would break the
+    // engine join (`axes sets are disjoint`). Prefer the lead-selection recipe
+    // surfaced by discover; fall back to the original lazy leaf otherwise.
+    const leadSelectionId = leadSelectionCol.id as string;
+    const primaryFromDiscover = discoveredCols.filter(
+      (c) => (c.id as string) === leadSelectionId && isColumnLazy(c),
     );
-    if (!leadSelectionCol) return undefined;
+    const primary: ColumnRecipe[] = primaryFromDiscover.length > 0
+      ? primaryFromDiscover
+      : [leadSelectionCol];
 
-    // Build filter/ranking spec lookup for columnsDisplayOptions matchers.
-    // Match by spec signature (name + domain) since ColumnMatcher receives spec, not ID.
+    const primaryIds = new Set(primary.map((c) => c.id as string));
+    const secondary = discoveredCols.filter((c) => !primaryIds.has(c.id as string));
+
+    // Build filter/rank id sets and lift them to selector form for the V3
+    // display rules — `match` is ColumnSelector, not a lambda.
     const filterColumnIds = new Set<string>(
       ctx.activeArgs?.filters
         .filter((f) => f.value?.column !== undefined)
@@ -362,42 +436,57 @@ export const platforma = BlockModelV3.create(blockDataModel)
         .filter((r) => r.value?.column !== undefined)
         .map((r) => r.value!.column as string),
     );
+    const filterRankIds = new Set<string>([...filterColumnIds, ...rankingColumnIds]);
     const kabatEnabled = ctx.activeArgs?.kabatNumbering ?? false;
 
-    const collectionResult = buildCollection(ctx, anchor);
-    const filterRankSpecs = new Set<string>();
-    if (collectionResult) {
-      for (const m of collectionResult.meta.allMatches) {
-        const idStr = m.column.id as string;
-        if (filterColumnIds.has(idStr) || rankingColumnIds.has(idStr)) {
-          filterRankSpecs.add(canonicalizeJson({
-            name: m.column.spec.name,
-            domain: m.column.spec.domain,
-          }));
-        }
-      }
-    }
-    const isFilterOrRank = (spec: PColumnSpec): boolean =>
-      filterRankSpecs.has(canonicalizeJson({ name: spec.name, domain: spec.domain }));
+    const collectionResult = buildCollection(ctx, anchorId);
+    const filterRankSelectorsList = collectionResult
+      ? filterRankSelectors(collectionResult.meta.allMatches, filterRankIds)
+      : [];
 
-    // Sort by ranking-order column (from sampledRows). V3 remaps the ID via originalId.
-    const rankingOrderCol = sampledRows.find(
-      (col) => col.spec.name === 'pl7.app/ranking-order',
-    );
-    const sorting: PTableSorting[] | undefined = rankingOrderCol
-      ? [{
-          column: { type: 'column', id: rankingOrderCol.id },
-          ascending: true,
-          naAndAbsentAreLeastValues: false,
-        }]
-      : undefined;
+    // Catch-all selectors for the "main sequence + amino-acid alphabet" group
+    // (vdj + peptide variants) shared by ordering and visibility rules.
+    const mainAaVdjSelector: RelaxedColumnSelector = {
+      domain: { 'pl7.app/alphabet': 'aminoacid' },
+      annotations: {
+        'pl7.app/vdj/isAssemblingFeature': 'true',
+        'pl7.app/vdj/isMainSequence': 'true',
+      },
+    };
+    const mainAaPeptideSelector: RelaxedColumnSelector = {
+      domain: { 'pl7.app/alphabet': 'aminoacid' },
+      annotations: {
+        'pl7.app/isAssemblingFeature': 'true',
+        'pl7.app/isMainSequence': 'true',
+      },
+    };
+
+    // Label columns on the row axis (clonotypeKey / scClonotypeKey / variantKey).
+    const rowLabelSelectors: RelaxedColumnSelector[] = [
+      'pl7.app/vdj/clonotypeKey',
+      'pl7.app/vdj/scClonotypeKey',
+      'pl7.app/variantKey',
+    ].map((axisName) => ({
+      name: [{ type: 'exact', value: Annotation.Label }],
+      axes: [{ name: [{ type: 'exact', value: axisName }] }],
+    }));
+
+    const visibilityDefault: RelaxedColumnSelector[] = [
+      { name: [{ type: 'exact', value: 'pl7.app/ranking-order' }] },
+      { name: [{ type: 'exact', value: 'pl7.app/vdj/inVivoScore' }] },
+      ...rowLabelSelectors,
+      mainAaVdjSelector,
+      mainAaPeptideSelector,
+      ...filterRankSelectorsList,
+    ];
+    if (kabatEnabled) {
+      // Selectors match values as regex — anchor prefix with `^`.
+      visibilityDefault.push({ name: '^pl7\\.app/vdj/kabatSequence' });
+    }
 
     return createPlDataTableV3(ctx, {
-      columns: {
-        sources,
-        anchors: { main: leadSelectionCol.spec },
-        selector: { mode: 'enrichment' },
-      },
+      primaryColumns: primary,
+      columns: secondary,
       tableState: ctx.data.tableState,
       primaryJoinType: 'full',
       sorting,
@@ -411,68 +500,37 @@ export const platforma = BlockModelV3.create(blockDataModel)
       },
       displayOptions: {
         ordering: [
-          {
-            match: (spec) => spec.name === Annotation.Label
-              && spec.axesSpec.length === 1
-              && (spec.axesSpec[0].name === 'pl7.app/vdj/clonotypeKey'
-                || spec.axesSpec[0].name === 'pl7.app/vdj/scClonotypeKey'
-                || spec.axesSpec[0].name === 'pl7.app/variantKey'),
-            priority: 1000000,
-          },
-          {
-            match: (spec) => {
-              const isAa = spec.domain?.['pl7.app/alphabet'] === 'aminoacid';
-              const isVdj = spec.annotations?.['pl7.app/vdj/isAssemblingFeature'] === 'true'
-                && spec.annotations?.['pl7.app/vdj/isMainSequence'] === 'true';
-              const isPeptide = spec.annotations?.['pl7.app/isAssemblingFeature'] === 'true'
-                && spec.annotations?.['pl7.app/isMainSequence'] === 'true';
-              return isAa && (isVdj || isPeptide);
-            },
-            priority: 999000,
-          },
-          {
-            match: isFilterOrRank,
-            priority: 7000,
-          },
+          { match: rowLabelSelectors, priority: 1000000 },
+          { match: [mainAaVdjSelector, mainAaPeptideSelector], priority: 999000 },
+          ...(filterRankSelectorsList.length > 0
+            ? [{ match: filterRankSelectorsList, priority: 7000 }]
+            : []),
         ],
         visibility: [
-          {
-            match: (spec) =>
-              spec.name === 'pl7.app/ranking-order'
-              || spec.name === 'pl7.app/vdj/inVivoScore'
-              || isFilterOrRank(spec)
-              || (spec.name === Annotation.Label
-                && spec.axesSpec.length === 1
-                && (spec.axesSpec[0].name === 'pl7.app/vdj/clonotypeKey'
-                  || spec.axesSpec[0].name === 'pl7.app/vdj/scClonotypeKey'
-                  || spec.axesSpec[0].name === 'pl7.app/variantKey'))
-                || (spec.annotations?.['pl7.app/vdj/isAssemblingFeature'] === 'true'
-                  && spec.annotations?.['pl7.app/vdj/isMainSequence'] === 'true'
-                  && spec.domain?.['pl7.app/alphabet'] === 'aminoacid')
-                || (spec.annotations?.['pl7.app/isAssemblingFeature'] === 'true'
-                  && spec.annotations?.['pl7.app/isMainSequence'] === 'true'
-                  && spec.domain?.['pl7.app/alphabet'] === 'aminoacid')
-                || (kabatEnabled && spec.name.startsWith('pl7.app/vdj/kabatSequence')),
-            visibility: 'default',
-          },
+          { match: visibilityDefault, visibility: 'default' },
           // Clone-to-cluster mapping (name: pl7.app/clusterId, axes: [clonotypeKey])
           // is always hidden — it duplicates the clusterId axis label column.
           {
-            match: (spec) => isClusterIdAxisName(spec.name),
+            match: [
+              { name: [{ type: 'exact', value: 'pl7.app/clusterId' }] },
+              { name: [{ type: 'exact', value: 'pl7.app/vdj/clusterId' }] },
+            ],
             visibility: 'hidden',
           },
-          // Catch-all: everything else optional (except linkers — V3 manages those)
+          // Linker columns are always hidden — V3 manages those internally.
           {
-            match: (spec) => spec.annotations?.['pl7.app/isLinkerColumn'] !== 'true',
-            visibility: 'optional',
+            match: { annotations: { 'pl7.app/isLinkerColumn': 'true' } },
+            visibility: 'hidden',
           },
+          // Catch-all: everything else optional.
+          { match: {}, visibility: 'optional' },
         ],
       },
     });
   })
 
   .output('calculating', (ctx) => {
-    if (getInputAnchorRef(ctx.data) === undefined)
+    if (getInputAnchorId(ctx.data) === undefined)
       return false;
 
     if (!ctx.outputs) return false;
@@ -485,113 +543,147 @@ export const platforma = BlockModelV3.create(blockDataModel)
 
   // Use UMAP output from ctx from clonotype-space block
   .outputWithStatus('umapPf', (ctx) => {
-    const anchor = getInputAnchorRef(ctx.data);
-    if (anchor === undefined)
-      return undefined;
+    const anchorId = getInputAnchorId(ctx.data);
+    if (anchorId === undefined) return undefined;
 
-    const umap = ctx.resultPool.getAnchoredPColumns(
-      { main: anchor },
-      [
-        {
-          axes: [{ anchor: 'main', idx: 1 }],
-          namePattern: '^pl7\\.app/umap[12]$',
+    const anchorSpec = Column(anchorId)?.getSpec();
+    if (!anchorSpec) return undefined;
+    const rowAxisName = anchorSpec.axesSpec[1]?.name;
+    if (!rowAxisName) return undefined;
+
+    const umap = ColumnsCollection(['result_pool'])
+      .discover({
+        anchors: { main: anchorSpec },
+        include: {
+          name: [
+            { type: 'exact', value: 'pl7.app/umap1' },
+            { type: 'exact', value: 'pl7.app/umap2' },
+          ],
+          axes: [{ name: [{ type: 'exact', value: rowAxisName }] }],
+          partialAxesMatch: true,
         },
-      ],
-    );
+      })
+      .getColumns();
 
-    if (umap === undefined || umap.length === 0)
-      return undefined;
+    if (umap.length === 0) return undefined;
 
-    const sampledRows = ctx.outputs?.resolve({ field: 'sampledRows', assertFieldType: 'Input', allowPermanentAbsence: true })?.getPColumns();
+    const umapPCols = recipesToPColumns(umap);
+    if (umapPCols === undefined) return undefined;
 
-    return createPFrameForGraphs(ctx, [...umap, ...(sampledRows ?? [])]);
+    const sampledRowsAccessor = ctx.outputs?.resolve({
+      field: 'sampledRows',
+      assertFieldType: 'Input',
+      allowPermanentAbsence: true,
+    });
+    const sampledRowsPCols = sampledRowsAccessor
+      ? recipesToPColumns(ColumnsCollection([sampledRowsAccessor]).getColumns())
+      : [];
+    if (sampledRowsPCols === undefined) return undefined;
+
+    return createPFrameForGraphs(ctx, [...umapPCols, ...sampledRowsPCols]);
   })
 
   .outputWithStatus('umapPcols', (ctx) => {
-    const anchor = getInputAnchorRef(ctx.data);
-    if (anchor === undefined)
-      return undefined;
+    const anchorId = getInputAnchorId(ctx.data);
+    if (anchorId === undefined) return undefined;
 
-    const umap = ctx.resultPool.getAnchoredPColumns(
-      { main: anchor },
-      [
-        {
-          axes: [{ anchor: 'main', idx: 1 }],
-          namePattern: '^pl7\\.app/umap[12]$',
+    const anchorSpec = Column(anchorId)?.getSpec();
+    if (!anchorSpec) return undefined;
+    const rowAxisName = anchorSpec.axesSpec[1]?.name;
+    if (!rowAxisName) return undefined;
+
+    const umap = ColumnsCollection(['result_pool'])
+      .discover({
+        anchors: { main: anchorSpec },
+        include: {
+          name: [
+            { type: 'exact', value: 'pl7.app/umap1' },
+            { type: 'exact', value: 'pl7.app/umap2' },
+          ],
+          axes: [{ name: [{ type: 'exact', value: rowAxisName }] }],
+          partialAxesMatch: true,
         },
-      ],
-    );
+      })
+      .getColumns();
 
-    if (umap === undefined || umap.length === 0)
-      return undefined;
+    if (umap.length === 0) return undefined;
 
-    const sampledRows = ctx.outputs?.resolve({ field: 'sampledRows', assertFieldType: 'Input', allowPermanentAbsence: true })?.getPColumns();
+    const sampledRowsAccessor = ctx.outputs?.resolve({
+      field: 'sampledRows',
+      assertFieldType: 'Input',
+      allowPermanentAbsence: true,
+    });
+    const sampledRows = sampledRowsAccessor
+      ? ColumnsCollection([sampledRowsAccessor]).getColumns()
+      : [];
 
-    return [...umap, ...(sampledRows ?? [])].map(
-      (c) =>
+    // isColumnLazy required because PColumnIdAndSpec.columnId is PObjectId —
+    // only leaves carry that. Wrappers expose ColumnUniversalId only.
+    return [...umap, ...sampledRows]
+      .map((c) =>
         ({
-          columnId: c.id,
-          spec: c.spec,
+          columnId: c.id as PObjectId,
+          spec: c.getSpec(),
         } satisfies PColumnIdAndSpec),
-    );
+      );
   })
 
   .output('hasClusterData', (ctx) => {
-    const result = buildCollection(ctx, getInputAnchorRef(ctx.data));
+    const result = buildCollection(ctx, getInputAnchorId(ctx.data));
     if (!result) return false;
 
-    return result.meta.allMatches.some((m) =>
-      m.column.spec.axesSpec.some((a) => isClusterIdAxisName(a.name)),
+    return result.meta.allMatches.some((c) =>
+      c.getSpec().axesSpec.some((a) => isClusterIdAxisName(a.name)),
     );
   })
 
   .output('clusterColumnOptions', (ctx) => {
-    const anchor = getInputAnchorRef(ctx.data);
-    if (anchor === undefined)
-      return undefined;
+    const anchorId = getInputAnchorId(ctx.data);
+    if (anchorId === undefined) return undefined;
 
-    const anchorSpec = ctx.resultPool.getPColumnSpecByRef(anchor);
-    if (anchorSpec === undefined)
-      return undefined;
+    const anchorSpec = Column(anchorId)?.getSpec();
+    if (anchorSpec === undefined) return undefined;
 
-    // Get linker columns using the same iteration order as util.ts
-    const options: Array<{ label: string; ref: PlRef }> = [];
+    const clonotypeAxisName = anchorSpec.axesSpec[1]?.name;
+    if (clonotypeAxisName === undefined) return undefined;
 
-    for (const idx of [0, 1]) {
-      let axesToMatch;
-      if (idx === 0) {
-        axesToMatch = [{}, anchorSpec.axesSpec[1]];
-      } else {
-        axesToMatch = [anchorSpec.axesSpec[1], {}];
-      }
+    // Discover linker columns that touch both the clonotype row axis and a
+    // cluster-id axis (in either order). Names are matched via regex on the
+    // cluster-id axis to cover both prefixed and unprefixed clusterId forms.
+    const linkers = ColumnsCollection(['result_pool']).filter({
+      include: {
+        annotations: { 'pl7.app/isLinkerColumn': 'true' },
+        axes: [
+          { name: [{ type: 'exact', value: clonotypeAxisName }] },
+          { name: '^pl7\\.app/(vdj/)?clusterId$' },
+        ],
+      },
+    });
 
-      const linkers = ctx.resultPool.getOptions([
-        {
-          axes: axesToMatch,
-          annotations: { 'pl7.app/isLinkerColumn': 'true' },
-        },
-      ], {
-        label: {
-          forceTraceElements: CLUSTERING_TRACE_TYPES,
-        },
-      });
+    const baseOptions = deriveColumnOptions(linkers, {
+      forceTraceElements: CLUSTERING_TRACE_TYPES,
+    });
+    if (baseOptions.length === 0) return undefined;
 
-      for (const link of linkers) {
-        const linkerSpec = ctx.resultPool.getPColumnSpecByRef(link.ref);
-        if (!linkerSpec?.axesSpec.some((axis) => isClusterIdAxisName(axis.name))) {
-          continue;
-        }
-        // Extract clustering trace element label directly to avoid verbose
-        // disambiguation when vdj-integration linkers are present in the pool.
-        let label = 'Cluster';
+    // Override the derived label with the clustering trace element's own
+    // label when available — avoids verbose disambiguation when multiple
+    // vdj-integration linkers exist in the pool.
+    const options = baseOptions.map((opt) => {
+      const linkerSpec = Column(opt.id)?.getSpec();
+      let label = opt.label || 'Cluster';
+      if (linkerSpec) {
         try {
-          const trace = JSON.parse(linkerSpec.annotations?.['pl7.app/trace'] ?? '[]') as { type?: string; label?: string }[];
-          const clusteringElement = trace.find((t) => CLUSTERING_TRACE_TYPES.includes(t.type ?? ''));
+          const trace = JSON.parse(
+            linkerSpec.annotations?.[Annotation.Trace] ?? '[]',
+          ) as { type?: string; label?: string }[];
+          const clusteringElement = trace.find(
+            (t) => CLUSTERING_TRACE_TYPES.includes(t.type ?? ''),
+          );
           if (clusteringElement?.label) label = clusteringElement.label;
-        } catch { /* use default */ }
-        options.push({ label, ref: link.ref });
+        } catch { /* keep derived label */ }
       }
-    }
+      return { label, id: opt.id };
+    });
 
     return options.length > 0 ? options : undefined;
   })
@@ -613,9 +705,9 @@ export const platforma = BlockModelV3.create(blockDataModel)
   .subtitle((ctx) => ctx.data.customBlockLabel || ctx.data.defaultBlockLabel)
 
   .sections((ctx) => {
-    const ref = getInputAnchorRef(ctx.data);
-    const isPeptide = ref !== undefined
-      && ctx.resultPool.getPColumnSpecByRef(ref)?.axesSpec[1]?.name === 'pl7.app/variantKey';
+    const id = getInputAnchorId(ctx.data);
+    const isPeptide = id !== undefined
+      && Column(id)?.getSpec()?.axesSpec[1]?.name === 'pl7.app/variantKey';
 
     const sections: Array<{ type: 'link'; href: `/${string}`; label: string }> = [
       { type: 'link', href: '/', label: strings.titles.main },

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -20,10 +20,10 @@ import {
   createPFrameForGraphs,
   createPlDataTableV3,
   deriveColumnOptions,
-  deriveLabels,
-  isColumnLazy,
+  deriveDistinctLabels, isColumnLazy,
   isHiddenFromGraphColumn,
   isHiddenFromUIColumn,
+  isLeafColumn,
   isPColumnSpec,
 } from '@platforma-sdk/model';
 import {
@@ -181,14 +181,11 @@ export const platforma = BlockModelV3.create(blockDataModel)
     const result = buildCollection(ctx, anchorId);
     if (!result || anchorId === undefined) return undefined;
 
-    const labeled = deriveLabels(
-      result.meta.allMatches,
-      (c) => c.getSpec(),
-      { includeNativeLabel: true },
-    );
-    const options = labeled.map(({ value, label }) => ({
+    const columns = result.meta.allMatches;
+    const labeled = deriveDistinctLabels(columns.map((c) => c.getSpec()), { includeNativeLabel: true });
+    const options = labeled.map((label, i) => ({
       label,
-      value: recipeToColumnId(value, anchorId),
+      value: recipeToColumnId(columns[i], anchorId),
     }));
 
     return {
@@ -209,15 +206,10 @@ export const platforma = BlockModelV3.create(blockDataModel)
     const rankable = result.meta.allMatches.filter(
       (c) => c.getSpec().valueType !== 'String',
     );
-
-    const labeled = deriveLabels(
-      rankable,
-      (c) => c.getSpec(),
-      { includeNativeLabel: true },
-    );
-    const options = labeled.map(({ value, label }) => ({
+    const labeled = deriveDistinctLabels(rankable.map((c) => c.getSpec()), { includeNativeLabel: true });
+    const options = labeled.map((label, i) => ({
       label,
-      value: recipeToColumnId(value, anchorId),
+      value: recipeToColumnId(rankable[i], anchorId),
     }));
 
     if (result.meta.hasInVivoScore) {
@@ -354,7 +346,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
     const leadSelectionCol = sampledRowsCollection
       .filter({ include: { name: [{ type: 'exact', value: 'pl7.app/lead-selection' }] } })
       .getColumns()[0];
-    if (!leadSelectionCol || !isColumnLazy(leadSelectionCol)) return undefined;
+    if (!leadSelectionCol || !isLeafColumn(leadSelectionCol)) return undefined;
 
     // Verify sampledRows belong to current inputAnchor by checking axes
     const leadSelectionSpec = leadSelectionCol.getSpec();
@@ -396,33 +388,23 @@ export const platforma = BlockModelV3.create(blockDataModel)
       .discover({
         anchors: { main: leadSelectionCol.getSpec() },
         mode: 'enrichment',
-        exclude: [
-          { annotations: { [Annotation.Trace]: '.*antibody-tcr-lead-selection.*' } },
-        ],
+        exclude: [{ annotations: { [Annotation.Trace]: '.*antibody-tcr-lead-selection.*' } }],
       })
-      .getColumns()
-      // Sandbox-side: File valueType and the "axes.length > 2 linker" rule
-      // can't be expressed as selectors — File is not in the ColumnValueType
-      // union. Every survivor pays one getSpec round-trip.
-      .filter((c) => {
-        const spec = c.getSpec();
-        if ((spec.valueType as string) === 'File') return false;
-        return !(spec.annotations?.['pl7.app/isLinkerColumn'] === 'true' && spec.axesSpec.length > 2);
-      });
+      .getColumns();
 
-    // Primary must be leaves only — multi-axis Discovered hits would break the
-    // engine join (`axes sets are disjoint`). Prefer the lead-selection recipe
-    // surfaced by discover; fall back to the original lazy leaf otherwise.
-    const leadSelectionId = leadSelectionCol.id as string;
+    // Primary must be leaf-form only — multi-axis Discovered hits would break
+    // the engine join (`axes sets are disjoint`). Prefer the lead-selection
+    // recipe surfaced by discover; fall back to the original leaf otherwise.
+    const leadSelectionId = leadSelectionCol.id;
     const primaryFromDiscover = discoveredCols.filter(
-      (c) => (c.id as string) === leadSelectionId && isColumnLazy(c),
+      (c) => c.id === leadSelectionId && isLeafColumn(c),
     );
     const primary: ColumnRecipe[] = primaryFromDiscover.length > 0
       ? primaryFromDiscover
       : [leadSelectionCol];
 
-    const primaryIds = new Set(primary.map((c) => c.id as string));
-    const secondary = discoveredCols.filter((c) => !primaryIds.has(c.id as string));
+    const primaryIds = new Set(primary.map((c) => c.id));
+    const secondary = discoveredCols.filter((c) => !primaryIds.has(c.id));
 
     // Build filter/rank id sets and lift them to selector form for the V3
     // display rules — `match` is ColumnSelector, not a lambda.
@@ -617,8 +599,6 @@ export const platforma = BlockModelV3.create(blockDataModel)
       ? ColumnsCollection([sampledRowsAccessor]).getColumns()
       : [];
 
-    // isColumnLazy required because PColumnIdAndSpec.columnId is PObjectId —
-    // only leaves carry that. Wrappers expose ColumnUniversalId only.
     return [...umap, ...sampledRows]
       .map((c) =>
         ({

--- a/model/src/types.ts
+++ b/model/src/types.ts
@@ -1,5 +1,5 @@
 import type { GraphMakerState } from '@milaboratories/graph-maker';
-import type { ColumnMatch, DatasetSelection, DataInfo, PColumn, PColumnValues, PlDataTableStateV2, PlMultiSequenceAlignmentModel, PlRef, PObjectId, TreeNodeAccessor } from '@platforma-sdk/model';
+import type { ColumnRecipe, ColumnUniversalId, DatasetSelection, PlDataTableStateV2, PlMultiSequenceAlignmentModel, PlRef } from '@platforma-sdk/model';
 import type { PlTableFilter } from './typesFilters';
 
 export * from './typesFilters';
@@ -32,6 +32,10 @@ export type LegacyUiState = {
   preset?: WorkflowPreset;
 };
 
+/** Stored shape at Ver_2026_02_25 — `inputAnchor` / `diversificationColumn` are
+ *  `PlRef`, mirroring what's on disk for projects saved at that version.
+ *  Do not retype these fields when the current `BlockData` changes — historical
+ *  steps must match what was actually persisted. */
 export type BlockData_Ver_2026_02_25 = {
   defaultBlockLabel: string;
   customBlockLabel: string;
@@ -55,50 +59,59 @@ export type BlockData_Ver_2026_02_25 = {
   preset?: WorkflowPreset;
 };
 
+/** Stored shape at Ver_2026_05_08 — adds `selectionPlotState`. Frozen so the
+ *  current `BlockData` can change without dragging historical aliases with it. */
 export type BlockData_Ver_2026_05_08 = BlockData_Ver_2026_02_25 & {
   selectionPlotState: GraphMakerState;
 };
 
-export type BlockData = Omit<BlockData_Ver_2026_05_08, 'inputAnchor'> & {
-  /**
-   * Dataset selection emitted by `PlDatasetSelector` (primary anchor + optional
-   * filter). Replaces the previous `inputAnchor: PlRef`; the args lambda
-   * unpacks it into the workflow's `inputAnchor` + `inputFilter`.
-   */
+/** Stored shape at Ver_2026_05_21 — `inputAnchor: PlRef` becomes
+ *  `input: DatasetSelection`. `diversificationColumn` is still a `PlRef`
+ *  at this version. */
+export type BlockData_Ver_2026_05_21 = Omit<BlockData_Ver_2026_05_08, 'inputAnchor'> & {
+  /** Dataset selection emitted by `PlDatasetSelector` (primary anchor + optional filter). */
   input?: DatasetSelection;
+};
+
+export type BlockData = Omit<BlockData_Ver_2026_05_21, 'diversificationColumn'> & {
+  /**
+   * Selected linker column for diversified ranking (grouping by cluster).
+   * Migrated from `PlRef` to `ColumnUniversalId` at Ver_2026_05_28.
+   * undefined = no diversification.
+   */
+  diversificationColumn?: ColumnUniversalId;
 };
 
 export type BlockArgs = {
   defaultBlockLabel: string;
   customBlockLabel: string;
-  inputAnchor?: PlRef;
+  /** Extracted from `data.input?.primary.column` (PlRef) at the args boundary
+   *  and converted via `createGlobalPObjectId`. */
+  inputAnchor?: ColumnUniversalId;
   /**
    * Optional filter column the user picked alongside the dataset in
-   * `PlDatasetSelector`. The workflow inner-joins this column into the clone
-   * table so all downstream stages see only the filtered clonotypes.
+   * `PlDatasetSelector`. Extracted from `data.input?.primary.filter` and
+   * converted to a `ColumnUniversalId`.
    */
-  inputFilter?: PlRef;
+  inputFilter?: ColumnUniversalId;
   topClonotypes: number;
   rankingOrder: RankingOrder[];
   filters: Filter[];
   kabatNumbering?: boolean;
   /** Selected linker column for diversified ranking (grouping by cluster). undefined = no diversification */
-  diversificationColumn?: PlRef;
+  diversificationColumn?: ColumnUniversalId;
 };
 
-// @todo: move this type to SDK
-export type Column = PColumn<DataInfo<TreeNodeAccessor> | TreeNodeAccessor | PColumnValues>;
-
 export type ScopedColumn = {
-  anchorRef: PlRef;
+  anchorRef: ColumnUniversalId;
   anchorName: string;
-  column: Column;
+  column: ColumnRecipe;
 };
 
 export type ScopedColumnId = {
-  anchorRef: PlRef;
+  anchorRef: ColumnUniversalId;
   anchorName: string;
-  column: PObjectId; // SUniversalPColumnId
+  column: ColumnUniversalId;
 };
 
 export type RankingOrder = {
@@ -151,9 +164,9 @@ export type PresetDefaults = {
 
 export type ColumnsMeta = {
   /** All discovered columns (direct + linked via linker traversal) */
-  allMatches: ColumnMatch[];
+  allMatches: ColumnRecipe[];
   /** Score columns (subset of allMatches with pl7.app/isScore annotation) */
-  scores: ColumnMatch[];
+  scores: ColumnRecipe[];
   defaultFilters: PlTableFiltersDefault[];
   defaultRankingOrder: RankingOrder[];
   /** True when SHM mutation columns are present and In Vivo Score should replace them in ranking */

--- a/model/src/util.ts
+++ b/model/src/util.ts
@@ -1,30 +1,61 @@
 import {
   Annotation,
-  ColumnCollectionBuilder, type AnchoredColumnCollection,
-  type AnchoredFindColumnsOptions,
+  Column,
+  ColumnsCollection,
+  createGlobalPObjectId,
   type AxisSpec,
-  type ColumnMatch,
+  type ColumnRecipe,
+  type ColumnsCollection as ColumnsCollectionType,
+  type ColumnUniversalId,
   type PColumnSpec,
   type PlRef,
+  type RelaxedColumnSelector,
   type RenderCtx,
-  type SUniversalPColumnId,
 } from '@platforma-sdk/model';
 import type { BlockArgs, BlockData, ColumnsMeta, PlTableFiltersDefault, RankingOrder, ScopedColumnId, WorkflowPreset } from './types';
 
-/** Underlying primary `PlRef` from `data.input` — undefined when no dataset is picked. */
+/** Underlying primary `PlRef` from `data.input` — undefined when no dataset is picked.
+ *  Kept for callers that still need a `PlRef` (e.g. `buildDatasetOptions` consumers). */
 export function getInputAnchorRef(data: Pick<BlockData, 'input'>): PlRef | undefined {
   return data.input?.primary.column;
 }
 
-/** Optional filter `PlRef` the user picked alongside the primary in `PlDatasetSelector`. */
-export function getInputFilterRef(data: Pick<BlockData, 'input'>): PlRef | undefined {
-  return data.input?.primary.filter;
+/** Canonical `ColumnUniversalId` for the primary anchor — derived from the
+ *  underlying result-pool leaf `PlRef`. Returns `undefined` when no dataset is picked. */
+export function getInputAnchorId(data: Pick<BlockData, 'input'>): ColumnUniversalId | undefined {
+  const ref = data.input?.primary.column;
+  return ref !== undefined ? createGlobalPObjectId(ref.blockId, ref.name) : undefined;
 }
 
-/** Common WASM exclude selectors shared across filter/rank/table discovery. */
-export const commonExcludeSelectors: NonNullable<AnchoredFindColumnsOptions['exclude']> = [
+/** Canonical `ColumnUniversalId` for the optional filter column picked alongside
+ *  the primary in `PlDatasetSelector`. */
+export function getInputFilterId(data: Pick<BlockData, 'input'>): ColumnUniversalId | undefined {
+  const ref = data.input?.primary.filter;
+  return ref !== undefined ? createGlobalPObjectId(ref.blockId, ref.name) : undefined;
+}
+
+/** Common exclude selectors shared across filter/rank/table discovery.
+ *  These run host-side — `commonExcludeSelectors` covers everything that can be
+ *  expressed as a selector. The sample-axis exclude depends on the anchor's
+ *  runtime sampleId axis name, so it is computed per-anchor inside
+ *  `buildCollection`, not baked into this static list.
+ *
+ *  Replaces the legacy JS-side `isSelectableMatch` post-filter:
+ *  - linker columns and sequence annotations excluded by annotation key,
+ *  - cluster-id mapping columns excluded by name (both prefixed / unprefixed),
+ *  - `pl7.app/label` excluded by exact name,
+ *  - self-trace excluded via `pl7.app/trace` regex. */
+export const commonExcludeSelectors: RelaxedColumnSelector[] = [
   { annotations: { 'pl7.app/isLinkerColumn': 'true' } },
   { annotations: { 'pl7.app/sequence/isAnnotation': 'true' } },
+  // cluster-id mapping columns — both unprefixed (post-peptide-adaptation) and
+  // `pl7.app/vdj/`-prefixed (pre-peptide). Selector values are regex strings;
+  // `.` and `/` are escaped so the literal name matches.
+  { name: [{ type: 'exact', value: 'pl7.app/clusterId' }, { type: 'exact', value: 'pl7.app/vdj/clusterId' }] },
+  // label columns
+  { name: [{ type: 'exact', value: 'pl7.app/label' }] },
+  // self-trace — columns produced by this block carry this trace fragment.
+  { annotations: { [Annotation.Trace]: '.*antibody-tcr-lead-selection.*' } },
 ];
 
 /** Cluster-id axis / column names. Both unprefixed (post-peptide-adaptation)
@@ -36,22 +67,13 @@ export const CLUSTER_ID_AXIS_NAMES: ReadonlySet<string> = new Set([
 ]);
 export const isClusterIdAxisName = (name: string): boolean => CLUSTER_ID_AXIS_NAMES.has(name);
 
-/** JS post-filter for column matches — excludes sampleId-axis, cluster mapping, label,
- *  and columns produced by this block. */
-export function isSelectableMatch(m: ColumnMatch, sampleAxisName: string): boolean {
-  return !m.column.spec.axesSpec.some((a) => a.name === sampleAxisName)
-    && !isClusterIdAxisName(m.column.spec.name)
-    && m.column.spec.name !== 'pl7.app/label'
-    && !m.column.spec.annotations?.[Annotation.Trace]?.includes('antibody-tcr-lead-selection');
-}
-
-/** Converts a ColumnMatch to a ScopedColumnId for the workflow wire format. */
-export function matchToColumnId(match: ColumnMatch, anchorRef: PlRef): ScopedColumnId {
-  return { anchorRef, anchorName: 'main', column: match.column.id };
+/** Converts a `ColumnRecipe` to a `ScopedColumnId` for the workflow wire format. */
+export function recipeToColumnId(recipe: ColumnRecipe, anchorRef: ColumnUniversalId): ScopedColumnId {
+  return { anchorRef, anchorName: 'main', column: recipe.id };
 }
 
 // Sentinel column ID for the computed In Vivo Score ranking
-export const IN_VIVO_SCORE_COLUMN_ID = 'pl7.app/vdj/inVivoScore' as SUniversalPColumnId;
+export const IN_VIVO_SCORE_COLUMN_ID = 'pl7.app/vdj/inVivoScore' as ColumnUniversalId;
 
 // SHM mutation columns that are replaced by In Vivo Score in ranking.
 export const IN_VIVO_MUTATION_COLUMNS = new Set([
@@ -161,49 +183,46 @@ export function getVisibleClusterAxes<T extends { id: unknown; spec: { axesSpec:
 }
 
 /**
- * Builds an AnchoredColumnCollection from the result pool and computes column metadata
- * (scores, defaults, presets). Replaces the old getColumns() function.
+ * Discovers all columns related to the input anchor in the result pool and
+ * computes column metadata (scores, defaults, presets).
+ *
+ * The returned `collection` is the same `ColumnsCollection` that produced
+ * `allMatches` — callers can chain further `.discover` / `.filter` calls
+ * against it without re-running the anchor + exclude pipeline.
  */
 export function buildCollection(
   ctx: RenderCtx<BlockArgs, BlockData>,
-  inputAnchor: PlRef | undefined,
-): { collection: AnchoredColumnCollection; meta: ColumnsMeta; sampleAxisName: string } | undefined {
+  inputAnchor: ColumnUniversalId | undefined,
+): { collection: ColumnsCollectionType; meta: ColumnsMeta; sampleAxisName: string; anchorSpec: PColumnSpec } | undefined {
   if (!inputAnchor) return undefined;
 
-  const anchorSpec = ctx.resultPool.getPColumnSpecByRef(inputAnchor);
+  const anchorSpec = Column(inputAnchor)?.getSpec();
   if (!anchorSpec) return undefined;
 
-  // Exclude columns unsupported by the WASM spec frame:
-  // - File value type is not recognized
-  // - Linker columns with >2 axes have >2 connected components, which the spec frame rejects
-  const resultPoolColumns = ctx.resultPool.selectColumns(
-    (spec) => (spec.valueType as string) !== 'File'
-      && !(spec.annotations?.['pl7.app/isLinkerColumn'] === 'true' && spec.axesSpec.length > 2),
-  );
-  // Use the full 2-axis input anchor as PColumnSpec.
-  // This makes the anchored ID deriver use idx:0=sampleId, idx:1=clonotypeKey,
-  // matching the workflow's `addAnchor("main", inputAnchor)` reference frame —
-  // so column IDs from model discovery resolve correctly in bundleBuilder.
-  // Discovery scope is restricted via JS post-filter below: sampleId-axis columns
-  // are dropped to avoid ambiguous literal AxisIds in workflow's anchoredQuery.
-  const collection = new ColumnCollectionBuilder(ctx.getService('pframeSpec'))
-    .addSource(resultPoolColumns)
-    .build({ anchors: { main: anchorSpec } });
-  if (!collection) return undefined;
-
-  // Discover all enrichment-compatible columns keyed by clonotypeKey.
-  // The 'enrichment' mode ensures only columns whose axes are satisfiable
-  // by the trunk (clonotypeKey) — directly or via linker traversal — are returned.
   const sampleAxisName = anchorSpec.axesSpec[0].name;
-  const allMatches = collection.findColumns({
-    mode: 'related',
-    exclude: commonExcludeSelectors,
-    maxHops: 2,
-  }).filter((m) => isSelectableMatch(m, sampleAxisName));
 
-  // Extract scores
+  // Push every selector-expressible exclusion into the host-side `exclude` list:
+  // - shared `commonExcludeSelectors` (linker, sequence-annotation, cluster-id mapping, label, self-trace),
+  // - sample-axis exclusion derived from the runtime anchor sampleId axis name.
+  const exclude: RelaxedColumnSelector[] = [
+    ...commonExcludeSelectors,
+    { axes: [{ name: [{ type: 'exact', value: sampleAxisName }] }], partialAxesMatch: true },
+  ];
+
+  const collection = ColumnsCollection(['result_pool'])
+    .discover({
+      anchors: { main: anchorSpec },
+      mode: 'related',
+      maxHops: 2,
+      exclude,
+    });
+
+  const allMatches = collection.getColumns();
+
+  // Score columns — `pl7.app/isScore` annotation. This requires `getSpec()` per
+  // survivor, but the upstream `exclude` has already narrowed the set drastically.
   const scores = allMatches.filter(
-    (m) => m.column.spec.annotations?.['pl7.app/isScore'] === 'true',
+    (m) => m.getSpec().annotations?.['pl7.app/isScore'] === 'true',
   );
 
   // Compute defaults and presets
@@ -213,6 +232,7 @@ export function buildCollection(
   return {
     collection,
     sampleAxisName,
+    anchorSpec,
     meta: {
       allMatches,
       scores,
@@ -222,14 +242,14 @@ export function buildCollection(
   };
 }
 
-function computeDefaultFilters(scores: ColumnMatch[], anchorRef: PlRef): PlTableFiltersDefault[] {
+function computeDefaultFilters(scores: ColumnRecipe[], anchorRef: ColumnUniversalId): PlTableFiltersDefault[] {
   const defaultFilters: PlTableFiltersDefault[] = [];
 
   for (const score of scores) {
-    const valueString = score.column.spec.annotations?.['pl7.app/score/defaultCutoff'];
+    const spec = score.getSpec();
+    const valueString = spec.annotations?.['pl7.app/score/defaultCutoff'];
     if (valueString === undefined) continue;
 
-    const spec = score.column.spec;
     if (spec.valueType === 'String') {
       try {
         const value = JSON.parse(valueString) as string[];
@@ -241,12 +261,12 @@ function computeDefaultFilters(scores: ColumnMatch[], anchorRef: PlRef): PlTable
         const hasDiscreteValues = !!spec.annotations?.['pl7.app/discreteValues'];
         if (isDiscreteFilter && hasDiscreteValues && value.length > 0) {
           defaultFilters.push({
-            column: matchToColumnId(score, anchorRef),
+            column: recipeToColumnId(score, anchorRef),
             default: { type: 'string_in', reference: JSON.stringify(value) },
           });
         } else {
           defaultFilters.push({
-            column: matchToColumnId(score, anchorRef),
+            column: recipeToColumnId(score, anchorRef),
             default: { type: 'string_equals', reference: value[0] },
           });
         }
@@ -270,7 +290,7 @@ function computeDefaultFilters(scores: ColumnMatch[], anchorRef: PlRef): PlTable
         }
 
         defaultFilters.push({
-          column: matchToColumnId(score, anchorRef),
+          column: recipeToColumnId(score, anchorRef),
           default: {
             type: direction === 'increasing' ? 'number_greaterThanOrEqualTo' : 'number_lessThanOrEqualTo',
             reference: numericValue,
@@ -287,19 +307,23 @@ function computeDefaultFilters(scores: ColumnMatch[], anchorRef: PlRef): PlTable
 }
 
 function computePresets(
-  scores: ColumnMatch[],
+  scores: ColumnRecipe[],
   defaultFilters: PlTableFiltersDefault[],
-  anchorRef: PlRef,
+  anchorRef: ColumnUniversalId,
   anchorSpec: PColumnSpec,
 ): Omit<ColumnsMeta, 'allMatches' | 'scores' | 'defaultFilters'> {
   const isPeptide = anchorSpec.axesSpec[1]?.name === 'pl7.app/variantKey';
 
+  // Memoise getSpec() per score recipe — `hasInVivoScore`, `hasEnrichmentScores`
+  // and the per-preset filter/ranking passes below all read the same spec.
+  const scoreSpecs = scores.map((s) => ({ recipe: s, spec: s.getSpec() }));
+
   const hasInVivoScore = [...IN_VIVO_MUTATION_COLUMNS].every(
-    (name) => scores.some((s) => s.column.spec.name === name),
+    (name) => scoreSpecs.some(({ spec }) => spec.name === name),
   );
 
   const isEnrichmentColumn = (name: string) => name.startsWith('pl7.app/enrichment') || name.startsWith('pl7.app/vdj/enrichment');
-  const hasEnrichmentScores = scores.some((s) => isEnrichmentColumn(s.column.spec.name));
+  const hasEnrichmentScores = scoreSpecs.some(({ spec }) => isEnrichmentColumn(spec.name));
 
   // Peptide anchors always auto-select the peptide preset, regardless of which
   // score columns are upstream.
@@ -312,13 +336,13 @@ function computePresets(
         : undefined;
 
   // Default ranking: all non-String scores, excluding mutation columns when In Vivo Score replaces them
-  const defaultRankingOrder: RankingOrder[] = scores
-    .filter((s) => s.column.spec.valueType !== 'String')
-    .filter((s) => !hasInVivoScore || !IN_VIVO_MUTATION_COLUMNS.has(s.column.spec.name))
-    .map((s) => ({
-      id: `default-rank-${s.column.id}`,
-      value: matchToColumnId(s, anchorRef),
-      rankingOrder: (s.column.spec.annotations?.['pl7.app/score/rankingOrder'] as 'increasing' | 'decreasing') ?? 'decreasing',
+  const defaultRankingOrder: RankingOrder[] = scoreSpecs
+    .filter(({ spec }) => spec.valueType !== 'String')
+    .filter(({ spec }) => !hasInVivoScore || !IN_VIVO_MUTATION_COLUMNS.has(spec.name))
+    .map(({ recipe, spec }) => ({
+      id: `default-rank-${recipe.id}`,
+      value: recipeToColumnId(recipe, anchorRef),
+      rankingOrder: (spec.annotations?.['pl7.app/score/rankingOrder'] as 'increasing' | 'decreasing') ?? 'decreasing',
       isExpanded: false,
     }));
 
@@ -331,8 +355,8 @@ function computePresets(
 
   // Both presets intersect discovery-driven defaults with a per-preset
   // allowlist of spec names, so new upstream score columns can't bloat them.
-  const specNameByColumnId = new Map(
-    scores.map((s) => [matchToColumnId(s, anchorRef).column, s.column.spec.name]),
+  const specNameByColumnId = new Map<ColumnUniversalId, string>(
+    scoreSpecs.map(({ recipe, spec }) => [recipeToColumnId(recipe, anchorRef).column, spec.name]),
   );
 
   // In Vitro defaults
@@ -360,22 +384,22 @@ function computePresets(
     return specName !== undefined && IN_VIVO_FILTER_SPEC_NAMES.has(specName);
   });
 
-  const fractionCDRMutationsCol = scores.find(
-    (s) => s.column.spec.name === 'pl7.app/vdj/sequence/fractionCDRMutations',
+  const fractionCDRMutationsCol = scoreSpecs.find(
+    ({ spec }) => spec.name === 'pl7.app/vdj/sequence/fractionCDRMutations',
   );
   if (fractionCDRMutationsCol) {
     inVivoFilters.push({
-      column: matchToColumnId(fractionCDRMutationsCol, anchorRef),
+      column: recipeToColumnId(fractionCDRMutationsCol.recipe, anchorRef),
       default: { type: 'number_greaterThan', reference: 0.5 },
     });
   }
 
-  const nMutationsCol = scores.find(
-    (s) => s.column.spec.name === 'pl7.app/vdj/sequence/nMutations',
+  const nMutationsCol = scoreSpecs.find(
+    ({ spec }) => spec.name === 'pl7.app/vdj/sequence/nMutations',
   );
   if (nMutationsCol) {
     inVivoFilters.push({
-      column: matchToColumnId(nMutationsCol, anchorRef),
+      column: recipeToColumnId(nMutationsCol.recipe, anchorRef),
       default: { type: 'number_greaterThanOrEqualTo', reference: 3 },
     });
   }
@@ -395,11 +419,11 @@ function computePresets(
 
   // Peptide defaults: all numeric score columns; no SHM exclusions.
   const inPeptideDefaults = {
-    rankingOrder: scores
-      .filter((s) => s.column.spec.valueType !== 'String')
-      .map((s) => ({
-        value: matchToColumnId(s, anchorRef),
-        rankingOrder: (s.column.spec.annotations?.['pl7.app/score/rankingOrder'] as 'increasing' | 'decreasing') ?? 'decreasing',
+    rankingOrder: scoreSpecs
+      .filter(({ spec }) => spec.valueType !== 'String')
+      .map(({ recipe, spec }) => ({
+        value: recipeToColumnId(recipe, anchorRef),
+        rankingOrder: (spec.annotations?.['pl7.app/score/rankingOrder'] as 'increasing' | 'decreasing') ?? 'decreasing',
       })),
     filters: defaultFilters,
   };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,14 @@
     "shx": "catalog:"
   },
   "packageManager": "pnpm@9.14.4",
+  "pnpm": {
+    "overrides": {
+      "@platforma-sdk/model": "file:../platforma_1/sdk/model/package.tgz",
+      "@platforma-sdk/ui-vue": "file:../platforma_1/sdk/ui-vue/package.tgz",
+      "@platforma-sdk/workflow-tengo": "file:../platforma_1/sdk/workflow-tengo/package.tgz",
+      "@milaboratories/columns-collection-driver": "file:../platforma_1/lib/model/columns-collection-driver/package.tgz"
+    }
+  },
   "//pnpm": {
     "overrides": {
       "@platforma-sdk/workflow-tengo": "file:../platforma/sdk/workflow-tengo/package.tgz",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
       "@platforma-sdk/model": "file:../platforma_1/sdk/model/package.tgz",
       "@platforma-sdk/ui-vue": "file:../platforma_1/sdk/ui-vue/package.tgz",
       "@platforma-sdk/workflow-tengo": "file:../platforma_1/sdk/workflow-tengo/package.tgz",
-      "@milaboratories/columns-collection-driver": "file:../platforma_1/lib/model/columns-collection-driver/package.tgz"
+      "@milaboratories/columns-collection-driver": "file:../platforma_1/lib/model/columns-collection-driver/package.tgz",
+      "@milaboratories/pl-model-common": "file:../platforma_1/lib/model/common/package.tgz",
+      "@milaboratories/helpers": "file:../platforma_1/lib/util/helpers/package.tgz"
     }
   },
   "//pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,6 @@ catalogs:
     '@milaboratories/graph-maker':
       specifier: 1.4.3
       version: 1.4.3
-    '@milaboratories/helpers':
-      specifier: 1.14.2
-      version: 1.14.2
     '@milaboratories/multi-sequence-alignment':
       specifier: 1.47.13
       version: 1.47.13
@@ -87,6 +84,8 @@ overrides:
   '@platforma-sdk/ui-vue': file:../platforma_1/sdk/ui-vue/package.tgz
   '@platforma-sdk/workflow-tengo': file:../platforma_1/sdk/workflow-tengo/package.tgz
   '@milaboratories/columns-collection-driver': file:../platforma_1/lib/model/columns-collection-driver/package.tgz
+  '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
+  '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
 
 importers:
 
@@ -128,10 +127,10 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.3(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.3(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/helpers':
-        specifier: 'catalog:'
-        version: 1.14.2
+        specifier: file:../../platforma_1/lib/util/helpers/package.tgz
+        version: file:../platforma_1/lib/util/helpers/package.tgz
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
@@ -238,10 +237,10 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.3(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.3(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/multi-sequence-alignment':
         specifier: 'catalog:'
-        version: 1.47.13(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.47.13(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
@@ -1098,12 +1097,9 @@ packages:
       '@platforma-sdk/model': file:/Users/aleksandr/GIT/MILAB/platforma_1/sdk/model/package.tgz
       '@platforma-sdk/ui-vue': file:/Users/aleksandr/GIT/MILAB/platforma_1/sdk/ui-vue/package.tgz
 
-  '@milaboratories/helpers@1.14.1':
-    resolution: {integrity: sha512-GcxeGHakSLhewbA7hd8YVHnEzyi95UnzcZhgwvRPO+W7/svZc8sAGidAV5xgN/YmVmJfCRl7hfiIcL37+fm0Ew==}
-    engines: {node: '>=22'}
-
-  '@milaboratories/helpers@1.14.2':
-    resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
+  '@milaboratories/helpers@file:../platforma_1/lib/util/helpers/package.tgz':
+    resolution: {integrity: sha512-yljZZSfq7iZlRsU8uG1hWLTUd5nWaazIcHlNH8nD8XP5qzgOVFFcvQCELHtwOFEuVCBb+t5idgL5NG8FTx701Q==, tarball: file:../platforma_1/lib/util/helpers/package.tgz}
+    version: 1.14.2
     engines: {node: '>=22'}
 
   '@milaboratories/miplots4@1.2.1':
@@ -1124,7 +1120,7 @@ packages:
     resolution: {integrity: sha512-c24NW5LVAgj5j7WhM+8i3yT1G9l4sOLtqgkOCN/uWFQu3aReArzLOHNXjvztSk1pVPQZP9QjOCgKObOBHh9sDg==}
     version: 1.4.2
     peerDependencies:
-      '@milaboratories/pl-model-common': 1.39.0
+      '@milaboratories/pl-model-common': file:/Users/aleksandr/GIT/MILAB/platforma_1/lib/model/common/package.tgz
       '@platforma-sdk/model': file:/Users/aleksandr/GIT/MILAB/platforma_1/sdk/model/package.tgz
 
   '@milaboratories/pf-spec-driver@1.3.17':
@@ -1145,9 +1141,10 @@ packages:
 
   '@milaboratories/pframes-rs-wasm@1.1.35':
     resolution: {integrity: sha512-wmnEujKa47y+CguYFbeYPjzYAsdhOQO/oNKIyCl0cG/RDwi3qtioKj6DMIBQgjC+/yLPuMsPkjXh7aaPn9cvpA==}
+    version: 1.1.35
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
-      '@milaboratories/pl-model-common': 1.36.0
+      '@milaboratories/pl-model-common': file:/Users/aleksandr/GIT/MILAB/platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-model-middle-layer': 1.18.5
 
   '@milaboratories/pl-client@3.9.0':
@@ -1168,9 +1165,6 @@ packages:
   '@milaboratories/pl-error-like@1.12.10':
     resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
-  '@milaboratories/pl-error-like@1.12.9':
-    resolution: {integrity: sha512-9qlfawLFO4qG656ayvVSRholhhwlfXUvKKllXpHadqbnf2zO2oCd+5J76bPaFXDz/A3T+1eokCnCX74JsqCYSw==}
-
   '@milaboratories/pl-errors@1.4.12':
     resolution: {integrity: sha512-nhIPquOih6OKkLYMkDMzvUjWdn/m0X0lIQ6gNbAsWvpmv+KaOFp6noRPVqfGuvYuwwydPWZwGcEaG1zR7JBMrg==}
 
@@ -1188,11 +1182,9 @@ packages:
   '@milaboratories/pl-model-backend@1.3.3':
     resolution: {integrity: sha512-lXOLgKjgteuDnOgf3CMrT13TdD4z36CC8Lail1nvlHKF+ZDbd+nNvsCbIQ5UA/AUVQCd3ucGOacgX2soc/+TyQ==}
 
-  '@milaboratories/pl-model-common@1.36.0':
-    resolution: {integrity: sha512-BbFs3sTmy12ZKfTY6rFep0C5pfQoLvsjACN8EYaNIjXqOjQajt6velh4uGpB47+Uyp78k0cIWH4T04MIlixQrw==}
-
-  '@milaboratories/pl-model-common@1.42.0':
-    resolution: {integrity: sha512-ttX9OcQ9kgEhgyXZNkC7+vtsCaxjz+uNwmU8d2LlA56cpWgWV9WONi91w8nCRGFf9WboSgUVVaFj2XxiT9QHXQ==}
+  '@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz':
+    resolution: {integrity: sha512-JLj1oTkf3VdN6TqrKnai5SgZeF5YqTZx0710cfIXwFgSsiRAQgqPCLI/vgqWYBBwzkZu/ZTBsILBK4dec8TlgA==, tarball: file:../platforma_1/lib/model/common/package.tgz}
+    version: 1.42.0
 
   '@milaboratories/pl-model-middle-layer@1.18.5':
     resolution: {integrity: sha512-eIYE77rBva0k2KWDUmKJBHnGcyi/Tnc5rhlwZVb8q3hS3L4Upf4Pk7/lBL4ZLxYVMZ3/Da0Wp3EKYspUagi9Zg==}
@@ -6942,9 +6934,6 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
-  zod@3.23.8:
-    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
-
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -8143,8 +8132,8 @@ snapshots:
 
   '@milaboratories/columns-collection-driver@file:../platforma_1/lib/model/columns-collection-driver/package.tgz':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
 
   '@milaboratories/computable@2.9.4':
     dependencies:
@@ -8153,12 +8142,12 @@ snapshots:
       '@types/node': 24.5.2
       utility-types: 3.11.0
 
-  '@milaboratories/graph-maker@1.4.3(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/graph-maker@1.4.3(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@ag-grid-community/core': 32.3.9
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
       '@milaboratories/miplots4': 1.2.1(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)
+      '@milaboratories/pf-plots': 1.4.2(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)
       '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
       '@platforma-sdk/ui-vue': file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@types/d3-hierarchy': 3.1.7
@@ -8177,9 +8166,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@milaboratories/helpers@1.14.1': {}
-
-  '@milaboratories/helpers@1.14.2': {}
+  '@milaboratories/helpers@file:../platforma_1/lib/util/helpers/package.tgz': {}
 
   '@milaboratories/miplots4@1.2.1(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)':
     dependencies:
@@ -8219,11 +8206,11 @@ snapshots:
       - d3-scale-chromatic
       - supports-color
 
-  '@milaboratories/multi-sequence-alignment@1.47.13(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/multi-sequence-alignment@1.47.13(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@milaboratories/biowasm-tools': 2.0.2
       '@milaboratories/miplots4': 1.2.1(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)
+      '@milaboratories/pf-plots': 1.4.2(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)
       '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
       '@platforma-sdk/ui-vue': file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       vue: 3.5.25(typescript@5.6.3)
@@ -8237,10 +8224,10 @@ snapshots:
 
   '@milaboratories/pf-driver@1.4.14(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
       '@milaboratories/pframes-rs-node': 1.1.35
-      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.22.0)
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@milaboratories/pl-model-middle-layer@1.22.0)
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-model-middle-layer': 1.22.0
       '@milaboratories/ts-helpers': 1.8.2
       es-toolkit: 1.40.0
@@ -8250,19 +8237,19 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pf-plots@1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)':
+  '@milaboratories/pf-plots@1.4.2(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
       canonicalize: 2.1.0
       lodash: 4.18.1
 
   '@milaboratories/pf-spec-driver@1.3.17(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.20.0)
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
+      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@milaboratories/pl-model-middle-layer@1.20.0)
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-model-middle-layer': 1.20.0
       '@noble/hashes': 2.0.1
     transitivePeerDependencies:
@@ -8270,9 +8257,9 @@ snapshots:
 
   '@milaboratories/pf-spec-driver@1.3.19(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.22.0)
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
+      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@milaboratories/pl-model-middle-layer@1.22.0)
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-model-middle-layer': 1.22.0
       '@noble/hashes': 2.0.1
     transitivePeerDependencies:
@@ -8281,9 +8268,9 @@ snapshots:
   '@milaboratories/pframes-rs-node@1.1.35':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
-      '@milaboratories/helpers': 1.14.1
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
       '@milaboratories/pframes-rs-serv': 1.1.35
-      '@milaboratories/pl-model-common': 1.36.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
@@ -8291,33 +8278,33 @@ snapshots:
 
   '@milaboratories/pframes-rs-serv@1.1.35':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-model-common': 1.36.0
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-model-middle-layer': 1.18.5
       commander: 14.0.3
       selfsigned: 5.5.0
 
   '@milaboratories/pframes-rs-wasip2@1.1.35': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.20.0)':
+  '@milaboratories/pframes-rs-wasm@1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@milaboratories/pl-model-middle-layer@1.20.0)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
       '@milaboratories/pframes-rs-wasip2': 1.1.35
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-model-middle-layer': 1.20.0
 
-  '@milaboratories/pframes-rs-wasm@1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.22.0)':
+  '@milaboratories/pframes-rs-wasm@1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@milaboratories/pl-model-middle-layer@1.22.0)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
       '@milaboratories/pframes-rs-wasip2': 1.1.35
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-model-middle-layer': 1.22.0
 
   '@milaboratories/pl-client@3.9.0':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/ts-helpers': 1.8.2
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
@@ -8342,7 +8329,7 @@ snapshots:
       '@milaboratories/pl-config': 1.8.1
       '@milaboratories/pl-healthcheck': 1.0.0
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/ts-helpers': 1.8.2
       decompress: 4.2.1
       ssh2: 1.17.0
@@ -8356,9 +8343,9 @@ snapshots:
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/computable': 2.9.4
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
       '@milaboratories/pl-client': 3.9.0
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-tree': 1.12.2
       '@milaboratories/ts-helpers': 1.8.2
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
@@ -8382,11 +8369,6 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.25.76
 
-  '@milaboratories/pl-error-like@1.12.9':
-    dependencies:
-      json-stringify-safe: 5.0.1
-      zod: 3.23.8
-
   '@milaboratories/pl-errors@1.4.12':
     dependencies:
       '@milaboratories/pl-client': 3.9.0
@@ -8408,18 +8390,18 @@ snapshots:
   '@milaboratories/pl-middle-layer@1.61.7(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/computable': 2.9.4
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
       '@milaboratories/pf-driver': 1.4.14(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pf-spec-driver': 1.3.19(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pframes-rs-node': 1.1.35
-      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.22.0)
+      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@milaboratories/pl-model-middle-layer@1.22.0)
       '@milaboratories/pl-client': 3.9.0
       '@milaboratories/pl-deployments': 3.0.1
       '@milaboratories/pl-drivers': 1.14.12
       '@milaboratories/pl-errors': 1.4.12
       '@milaboratories/pl-http': 1.2.4
       '@milaboratories/pl-model-backend': 1.3.3
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-model-middle-layer': 1.22.0
       '@milaboratories/pl-tree': 1.12.2
       '@milaboratories/resolve-helper': 1.1.3
@@ -8451,40 +8433,34 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.36.0':
+  '@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-error-like': 1.12.9
-      canonicalize: 2.1.0
-      zod: 3.25.76
-
-  '@milaboratories/pl-model-common@1.42.0':
-    dependencies:
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
       '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
+      es-toolkit: 1.40.0
       zod: 3.25.76
 
   '@milaboratories/pl-model-middle-layer@1.18.5':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-model-common': 1.36.0
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       es-toolkit: 1.40.0
       utility-types: 3.11.0
       zod: 3.25.76
 
   '@milaboratories/pl-model-middle-layer@1.20.0':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       es-toolkit: 1.40.0
       utility-types: 3.11.0
       zod: 3.25.76
 
   '@milaboratories/pl-model-middle-layer@1.22.0':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       es-toolkit: 1.40.0
       utility-types: 3.11.0
       zod: 3.25.76
@@ -8602,13 +8578,13 @@ snapshots:
 
   '@milaboratories/ts-helpers@1.8.2':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
       canonicalize: 2.1.0
       denque: 2.1.0
 
   '@milaboratories/uikit@2.14.11(typescript@5.6.3)':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
       '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
       '@types/d3-array': 3.2.2
       '@types/d3-axis': 3.0.6
@@ -8987,7 +8963,7 @@ snapshots:
 
   '@platforma-open/milaboratories.software-ptabler.schema@1.15.9':
     dependencies:
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
 
   '@platforma-open/milaboratories.software-ptabler@1.16.1': {}
 
@@ -9013,7 +8989,7 @@ snapshots:
       '@aws-sdk/client-s3': 3.859.0
       '@milaboratories/pl-http': 1.2.4
       '@milaboratories/pl-model-backend': 1.3.3
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-model-middle-layer': 1.22.0
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.2
@@ -9047,9 +9023,9 @@ snapshots:
 
   '@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
       '@milaboratories/pl-error-like': 1.12.10
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-model-middle-layer': 1.20.0
       '@milaboratories/ptabler-expression-js': 1.2.25
       canonicalize: 2.1.0
@@ -9120,7 +9096,7 @@ snapshots:
     dependencies:
       '@milaboratories/columns-collection-driver': file:../platforma_1/lib/model/columns-collection-driver/package.tgz
       '@milaboratories/pf-spec-driver': 1.3.17(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/uikit': 2.14.11(typescript@5.6.3)
       '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
       '@types/d3-format': 3.0.4
@@ -15102,8 +15078,6 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
-
-  zod@3.23.8: {}
 
   zod@3.25.76: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,9 +39,6 @@ catalogs:
     '@platforma-sdk/eslint-config':
       specifier: 1.2.0
       version: 1.2.0
-    '@platforma-sdk/model':
-      specifier: 1.77.11
-      version: 1.77.11
     '@platforma-sdk/package-builder':
       specifier: 3.12.0
       version: 3.12.0
@@ -51,12 +48,6 @@ catalogs:
     '@platforma-sdk/test':
       specifier: 1.77.11
       version: 1.77.11
-    '@platforma-sdk/ui-vue':
-      specifier: 1.77.11
-      version: 1.77.11
-    '@platforma-sdk/workflow-tengo':
-      specifier: 5.26.0
-      version: 5.26.0
     '@types/lodash.debounce':
       specifier: ^4.0.9
       version: 4.0.9
@@ -90,6 +81,12 @@ catalogs:
     vue:
       specifier: 3.5.24
       version: 3.5.24
+
+overrides:
+  '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
+  '@platforma-sdk/ui-vue': file:../platforma_1/sdk/ui-vue/package.tgz
+  '@platforma-sdk/workflow-tengo': file:../platforma_1/sdk/workflow-tengo/package.tgz
+  '@milaboratories/columns-collection-driver': file:../platforma_1/lib/model/columns-collection-driver/package.tgz
 
 importers:
 
@@ -131,7 +128,7 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.3(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.11)(@platforma-sdk/ui-vue@1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.3(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/helpers':
         specifier: 'catalog:'
         version: 1.14.2
@@ -139,8 +136,8 @@ importers:
         specifier: 'catalog:'
         version: 0.1.2
       '@platforma-sdk/model':
-        specifier: 'catalog:'
-        version: 1.77.11
+        specifier: file:../../platforma_1/sdk/model/package.tgz
+        version: file:../platforma_1/sdk/model/package.tgz
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
@@ -155,8 +152,8 @@ importers:
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.38.0)(@stylistic/eslint-plugin@2.13.0(eslint@9.38.0)(typescript@5.6.3))(eslint-plugin-n@17.23.1(eslint@9.38.0)(typescript@5.6.3))(eslint-plugin-vue@9.33.0(eslint@9.38.0))(eslint@9.38.0)(globals@15.15.0)(typescript-eslint@8.46.2(eslint@9.38.0)(typescript@5.6.3))(typescript@5.6.3)
       '@platforma-sdk/ui-vue':
-        specifier: 'catalog:'
-        version: 1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+        specifier: file:../../platforma_1/sdk/ui-vue/package.tgz
+        version: file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@types/node':
         specifier: 'catalog:'
         version: 24.9.1
@@ -241,10 +238,10 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.3(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.11)(@platforma-sdk/ui-vue@1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.3(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/multi-sequence-alignment':
         specifier: 'catalog:'
-        version: 1.47.13(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.11)(@platforma-sdk/ui-vue@1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.47.13(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
@@ -252,11 +249,11 @@ importers:
         specifier: workspace:*
         version: link:../model
       '@platforma-sdk/model':
-        specifier: 'catalog:'
-        version: 1.77.11
+        specifier: file:../../platforma_1/sdk/model/package.tgz
+        version: file:../platforma_1/sdk/model/package.tgz
       '@platforma-sdk/ui-vue':
-        specifier: 'catalog:'
-        version: 1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+        specifier: file:../../platforma_1/sdk/ui-vue/package.tgz
+        version: file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@types/lodash.debounce':
         specifier: 'catalog:'
         version: 4.0.9
@@ -313,8 +310,8 @@ importers:
         specifier: workspace:*
         version: link:../software/umap
       '@platforma-sdk/workflow-tengo':
-        specifier: 'catalog:'
-        version: 5.26.0
+        specifier: file:../../platforma_1/sdk/workflow-tengo/package.tgz
+        version: file:../platforma_1/sdk/workflow-tengo/package.tgz
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
@@ -1086,15 +1083,20 @@ packages:
   '@milaboratories/biowasm-tools@2.0.2':
     resolution: {integrity: sha512-pe9bIiLni1vMr3tbM87bC2bYRYtwJWeHoZEGAN8WHLRvXW2ouNPvQT5b7LgSsnVtDXsU4L1Eu5cA4W/E94/5tA==}
 
+  '@milaboratories/columns-collection-driver@file:../platforma_1/lib/model/columns-collection-driver/package.tgz':
+    resolution: {integrity: sha512-pfCC+gRQHQEHPNGz26YK3IXZ7iJ/EmE062+g4uT/Zy9OZyuHOtx8yz5JtMSFQHpwhsaS1FV20pY1aHUqWDhw8w==, tarball: file:../platforma_1/lib/model/columns-collection-driver/package.tgz}
+    version: 0.1.0
+
   '@milaboratories/computable@2.9.4':
     resolution: {integrity: sha512-MgUqC3/8cE41k01dV8yne+K0bUYA457XFP7b/Sf5QrxDp6zWqCpWuCgLlsUzJNzFFLXaODWnpAFUvOZyQcq4jg==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/graph-maker@1.4.3':
     resolution: {integrity: sha512-67FjRlIolHpMLQYKgvHxjmZXe9bijVvM0vyfgrzwvXW51FxtREpiRjwBJWbmnAALw++vcrLVhuN+lAyhVpSQfw==}
+    version: 1.4.3
     peerDependencies:
-      '@platforma-sdk/model': 1.73.3
-      '@platforma-sdk/ui-vue': 1.73.3
+      '@platforma-sdk/model': file:/Users/aleksandr/GIT/MILAB/platforma_1/sdk/model/package.tgz
+      '@platforma-sdk/ui-vue': file:/Users/aleksandr/GIT/MILAB/platforma_1/sdk/ui-vue/package.tgz
 
   '@milaboratories/helpers@1.14.1':
     resolution: {integrity: sha512-GcxeGHakSLhewbA7hd8YVHnEzyi95UnzcZhgwvRPO+W7/svZc8sAGidAV5xgN/YmVmJfCRl7hfiIcL37+fm0Ew==}
@@ -1109,9 +1111,10 @@ packages:
 
   '@milaboratories/multi-sequence-alignment@1.47.13':
     resolution: {integrity: sha512-71PbFOil/+uPOurkkMtj/+9pYMLfx8o79bBgXCw0b98OYBTMseGXYw94vFemPqsFnZX2mVk6kwm/1oz41gZhxg==}
+    version: 1.47.13
     peerDependencies:
-      '@platforma-sdk/model': 1.73.3
-      '@platforma-sdk/ui-vue': 1.73.3
+      '@platforma-sdk/model': file:/Users/aleksandr/GIT/MILAB/platforma_1/sdk/model/package.tgz
+      '@platforma-sdk/ui-vue': file:/Users/aleksandr/GIT/MILAB/platforma_1/sdk/ui-vue/package.tgz
 
   '@milaboratories/pf-driver@1.4.14':
     resolution: {integrity: sha512-HdYdtCPFC6fThf7CU3Z5Wl/icQtEL7GIusBZrGkvgdrcxdopIWPxHdiCsQc1TSt3uSutqIn/hkFUOH7tZGYZPg==}
@@ -1119,9 +1122,13 @@ packages:
 
   '@milaboratories/pf-plots@1.4.2':
     resolution: {integrity: sha512-c24NW5LVAgj5j7WhM+8i3yT1G9l4sOLtqgkOCN/uWFQu3aReArzLOHNXjvztSk1pVPQZP9QjOCgKObOBHh9sDg==}
+    version: 1.4.2
     peerDependencies:
       '@milaboratories/pl-model-common': 1.39.0
-      '@platforma-sdk/model': 1.73.3
+      '@platforma-sdk/model': file:/Users/aleksandr/GIT/MILAB/platforma_1/sdk/model/package.tgz
+
+  '@milaboratories/pf-spec-driver@1.3.17':
+    resolution: {integrity: sha512-ShmOxNr8ocgZJiOaSC1bD23L1+oqwiaPS5Hh8Bqa9FO1FP7DWPMWV0LtVuUr7ZRGLzivjh9ccQbMyK9QuP5pbg==}
 
   '@milaboratories/pf-spec-driver@1.3.19':
     resolution: {integrity: sha512-gqEYJsE74e8cQ7RFUXZPFt7Tkv5HMUGIDnW6Fh8GEu/aPCto/AAviYkFkYB2eZEoyFPMCkTNg3XFYt5lGFszZg==}
@@ -1190,6 +1197,9 @@ packages:
   '@milaboratories/pl-model-middle-layer@1.18.5':
     resolution: {integrity: sha512-eIYE77rBva0k2KWDUmKJBHnGcyi/Tnc5rhlwZVb8q3hS3L4Upf4Pk7/lBL4ZLxYVMZ3/Da0Wp3EKYspUagi9Zg==}
 
+  '@milaboratories/pl-model-middle-layer@1.20.0':
+    resolution: {integrity: sha512-RGEJD0avNEBejl1SjCqn7RWNiK15xCNWMXfNziiHUcG4n+QxYm1sk5AezfWsKE3j3y1HdzZnYaoGto9Z1RoV7A==}
+
   '@milaboratories/pl-model-middle-layer@1.22.0':
     resolution: {integrity: sha512-MvdNkgPDaAoHnVU3IeeyGfZ9SynJwjsYKnvxNi3YQ9BzztwCDmSwrDijsVvo7lUBoeqLiXvLSr9ug98frKF6yg==}
 
@@ -1228,8 +1238,8 @@ packages:
     resolution: {integrity: sha512-bQHcEAeJXyV95Gyk0yoRS5t3M71mFaNG+SsY2o+i4GDDeByUXBiF+T5A0elc/rCyLK6NNlOblou0DHBYOiW3pQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.14.13':
-    resolution: {integrity: sha512-9klk/6DDheX6NotsIZ4h+FSZolc6VzMBchTVzZb+bmazmh9RQnmlGLUjqiP1/xOuSMAm2w6xUKbTSbSg07EY0A==}
+  '@milaboratories/uikit@2.14.11':
+    resolution: {integrity: sha512-6I20gxijl8AKIZFWDItWs6cut+v3G0sN3uOhUVTrRW8V77B+f/8e8+HKs+b9F/r5QQ0xP6nJN2nuO+a/EblZcw==}
 
   '@napi-rs/wasm-runtime@1.1.3':
     resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
@@ -1683,8 +1693,9 @@ packages:
       typescript: ~5.6.3
       typescript-eslint: ^8.17.0
 
-  '@platforma-sdk/model@1.77.11':
-    resolution: {integrity: sha512-qWu0flWA2vx0wAOzw0pQQzT1HZq4PrYRJVmImpg+htHDAt6KdbCc0d9XQnWpy2gMp4IcZ73rmeW+0tsUC4hshQ==}
+  '@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz':
+    resolution: {integrity: sha512-cVDkSRBI3obRCcjf0cHmxXA9T+1fCWLAl41pBkT3GcL+5nhrn2W5+tl8NJqD04Hx+pDJw7IF4irKTW23FMWykg==, tarball: file:../platforma_1/sdk/model/package.tgz}
+    version: 1.77.4
 
   '@platforma-sdk/package-builder@3.12.0':
     resolution: {integrity: sha512-bId52YqV5iLDAn9D9C3xaLD1bKyymGpHe2CDEZTqV+1yWCBh1RM6iH96JIXudVJdcmJaqwJWDw6X4WzStE6SCg==}
@@ -1698,11 +1709,13 @@ packages:
   '@platforma-sdk/test@1.77.11':
     resolution: {integrity: sha512-kAevtkLrAEV9k2eoNQyImKCATLaKLfj9g+gRUIB22CclwG7zReP5L3yajU6MnWPYU0g7Ns8G6Sn6EAtYkUqQMA==}
 
-  '@platforma-sdk/ui-vue@1.77.11':
-    resolution: {integrity: sha512-rjrGZXeBqFJHQoAQjNv0T49BnnkGLDW/t3hqdn0VzXbc+4C7s1n60hLqBS5J0CB254Vk8toBvOOsrsFTZeFTQQ==}
+  '@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz':
+    resolution: {integrity: sha512-Wu8sQIorHW1oGqoJlhQHd22Zxaw9m/PSA1Q1aBI8vDO3zTk4ZOP0LcS8T409Lv9HWv63MfOiZxMOydH/TmS+3g==, tarball: file:../platforma_1/sdk/ui-vue/package.tgz}
+    version: 1.77.4
 
-  '@platforma-sdk/workflow-tengo@5.26.0':
-    resolution: {integrity: sha512-lXoFzD0LsQqEF9WUkA48avAY7LOK9WdP7sIc/Bymu1fOm4peXEWWZFW7fYckCPhHEAwcyzjqh7jdE8pVXrfzvw==}
+  '@platforma-sdk/workflow-tengo@file:../platforma_1/sdk/workflow-tengo/package.tgz':
+    resolution: {integrity: sha512-mgHI8DZsHpdwNKbE7wXGnyWkpB9t9SmisknFnqVsdWEWVJbNT71LCYD86cnbg9HhRgH2Gbw4k37ivd0yU4Jyeg==, tarball: file:../platforma_1/sdk/workflow-tengo/package.tgz}
+    version: 5.25.0
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -8128,6 +8141,11 @@ snapshots:
 
   '@milaboratories/biowasm-tools@2.0.2': {}
 
+  '@milaboratories/columns-collection-driver@file:../platforma_1/lib/model/columns-collection-driver/package.tgz':
+    dependencies:
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-model-common': 1.42.0
+
   '@milaboratories/computable@2.9.4':
     dependencies:
       '@milaboratories/pl-error-like': 1.12.10
@@ -8135,14 +8153,14 @@ snapshots:
       '@types/node': 24.5.2
       utility-types: 3.11.0
 
-  '@milaboratories/graph-maker@1.4.3(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.11)(@platforma-sdk/ui-vue@1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/graph-maker@1.4.3(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@ag-grid-community/core': 32.3.9
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/miplots4': 1.2.1(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.11)
-      '@platforma-sdk/model': 1.77.11
-      '@platforma-sdk/ui-vue': 1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@milaboratories/pf-plots': 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)
+      '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
+      '@platforma-sdk/ui-vue': file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@types/d3-hierarchy': 3.1.7
       '@types/d3-scale': 4.0.9
       '@vueuse/core': 13.9.0(vue@3.5.25(typescript@5.6.3))
@@ -8201,13 +8219,13 @@ snapshots:
       - d3-scale-chromatic
       - supports-color
 
-  '@milaboratories/multi-sequence-alignment@1.47.13(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.11)(@platforma-sdk/ui-vue@1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/multi-sequence-alignment@1.47.13(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@milaboratories/biowasm-tools': 2.0.2
       '@milaboratories/miplots4': 1.2.1(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.11)
-      '@platforma-sdk/model': 1.77.11
-      '@platforma-sdk/ui-vue': 1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@milaboratories/pf-plots': 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)
+      '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
+      '@platforma-sdk/ui-vue': file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       vue: 3.5.25(typescript@5.6.3)
     transitivePeerDependencies:
       - '@milaboratories/pl-model-common'
@@ -8232,13 +8250,23 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pf-plots@1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.11)':
+  '@milaboratories/pf-plots@1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.42.0
-      '@platforma-sdk/model': 1.77.11
+      '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
       canonicalize: 2.1.0
       lodash: 4.18.1
+
+  '@milaboratories/pf-spec-driver@1.3.17(@bytecodealliance/preview2-shim@0.17.8)':
+    dependencies:
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.20.0)
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-middle-layer': 1.20.0
+      '@noble/hashes': 2.0.1
+    transitivePeerDependencies:
+      - '@bytecodealliance/preview2-shim'
 
   '@milaboratories/pf-spec-driver@1.3.19(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
@@ -8270,6 +8298,13 @@ snapshots:
       selfsigned: 5.5.0
 
   '@milaboratories/pframes-rs-wasip2@1.1.35': {}
+
+  '@milaboratories/pframes-rs-wasm@1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.20.0)':
+    dependencies:
+      '@bytecodealliance/preview2-shim': 0.17.8
+      '@milaboratories/pframes-rs-wasip2': 1.1.35
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-middle-layer': 1.20.0
 
   '@milaboratories/pframes-rs-wasm@1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.22.0)':
     dependencies:
@@ -8390,8 +8425,8 @@ snapshots:
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.2
       '@platforma-sdk/block-tools': 2.9.0
-      '@platforma-sdk/model': 1.77.11
-      '@platforma-sdk/workflow-tengo': 5.26.0
+      '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
+      '@platforma-sdk/workflow-tengo': file:../platforma_1/sdk/workflow-tengo/package.tgz
       canonicalize: 2.1.0
       denque: 2.1.0
       es-toolkit: 1.40.0
@@ -8434,6 +8469,14 @@ snapshots:
     dependencies:
       '@milaboratories/helpers': 1.14.1
       '@milaboratories/pl-model-common': 1.36.0
+      es-toolkit: 1.40.0
+      utility-types: 3.11.0
+      zod: 3.25.76
+
+  '@milaboratories/pl-model-middle-layer@1.20.0':
+    dependencies:
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-model-common': 1.42.0
       es-toolkit: 1.40.0
       utility-types: 3.11.0
       zod: 3.25.76
@@ -8563,10 +8606,10 @@ snapshots:
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.14.13(typescript@5.6.3)':
+  '@milaboratories/uikit@2.14.11(typescript@5.6.3)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@platforma-sdk/model': 1.77.11
+      '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
       '@types/d3-array': 3.2.2
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -9002,16 +9045,17 @@ snapshots:
       typescript: 5.6.3
       typescript-eslint: 8.46.2(eslint@9.38.0)(typescript@5.6.3)
 
-  '@platforma-sdk/model@1.77.11':
+  '@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-error-like': 1.12.10
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.22.0
+      '@milaboratories/pl-model-middle-layer': 1.20.0
       '@milaboratories/ptabler-expression-js': 1.2.25
       canonicalize: 2.1.0
       es-toolkit: 1.40.0
       fast-json-patch: 3.1.1
+      lru-cache: 11.2.2
       utility-types: 3.11.0
       zod: 3.25.76
 
@@ -9048,8 +9092,8 @@ snapshots:
       '@milaboratories/pl-client': 3.9.0
       '@milaboratories/pl-middle-layer': 1.61.7(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pl-tree': 1.12.2
-      '@platforma-sdk/model': 1.77.11
-      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3(@types/node@24.9.1)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.16(@types/node@24.9.1)(lightningcss@1.32.0)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))(vite@8.0.7(@types/node@24.9.1)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))
+      '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
+      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
       vitest: 4.1.3(@types/node@24.9.1)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.16(@types/node@24.9.1)(lightningcss@1.32.0)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))(vite@8.0.7(@types/node@24.9.1)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1))
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
@@ -9072,12 +9116,13 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/ui-vue@1.77.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
+  '@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
     dependencies:
-      '@milaboratories/pf-spec-driver': 1.3.19(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/columns-collection-driver': file:../platforma_1/lib/model/columns-collection-driver/package.tgz
+      '@milaboratories/pf-spec-driver': 1.3.17(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/uikit': 2.14.13(typescript@5.6.3)
-      '@platforma-sdk/model': 1.77.11
+      '@milaboratories/uikit': 2.14.11(typescript@5.6.3)
+      '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.1
@@ -9108,7 +9153,7 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/workflow-tengo@5.26.0':
+  '@platforma-sdk/workflow-tengo@file:../platforma_1/sdk/workflow-tengo/package.tgz':
     dependencies:
       '@milaboratories/pframes-rs-wasip2': 1.1.35
       '@milaboratories/software-pframes-conv': 2.2.9
@@ -12073,7 +12118,7 @@ snapshots:
       vite: 8.0.7(@types/node@24.9.1)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)
       vue: 3.5.25(typescript@5.6.3)
 
-  '@vitest/coverage-istanbul@4.1.3(vitest@4.1.3(@types/node@24.9.1)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.16(@types/node@24.9.1)(lightningcss@1.32.0)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))(vite@8.0.7(@types/node@24.9.1)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))':
+  '@vitest/coverage-istanbul@4.1.3(vitest@4.1.3)':
     dependencies:
       '@babel/core': 7.29.0
       '@istanbuljs/schema': 0.1.3
@@ -14900,7 +14945,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.9.1
-      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3(@types/node@24.9.1)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.16(@types/node@24.9.1)(lightningcss@1.32.0)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))(vite@8.0.7(@types/node@24.9.1)(sass-embedded@1.93.2)(sass@1.93.2)(yaml@2.8.1)))
+      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
     transitivePeerDependencies:
       - msw
 

--- a/ui/src/composables/useAnchorSyncedDefaults.ts
+++ b/ui/src/composables/useAnchorSyncedDefaults.ts
@@ -1,6 +1,5 @@
 import type { ScopedColumnId } from '@platforma-open/milaboratories.top-antibodies.model';
-import type { PlRef } from '@platforma-sdk/model';
-import { plRefsEqual } from '@platforma-sdk/model';
+import type { ColumnUniversalId } from '@platforma-sdk/model';
 import { computed, ref, watch } from 'vue';
 
 export interface ConfigWithOptions {
@@ -10,7 +9,7 @@ export interface ConfigWithOptions {
 
 export interface UseAnchorSyncedDefaultsOptions {
   /** Getter for the current input anchor */
-  getAnchor: () => PlRef | undefined;
+  getAnchor: () => ColumnUniversalId | undefined;
   /** Getter for the config (options + defaults) */
   getConfig: () => ConfigWithOptions | undefined;
   /** Function to clear the UI state */
@@ -59,7 +58,7 @@ export function useAnchorSyncedDefaults(options: UseAnchorSyncedDefaultsOptions)
   } = options;
 
   // Track which anchor+preset combo we've applied defaults for
-  const appliedForAnchor = ref<PlRef | null>(null);
+  const appliedForAnchor = ref<ColumnUniversalId | null>(null);
   const appliedForPreset = ref<string | null>(null);
 
   // Extract the config's anchor key for efficient watching (avoids deep: true)
@@ -67,23 +66,23 @@ export function useAnchorSyncedDefaults(options: UseAnchorSyncedDefaultsOptions)
     const config = getConfig();
     if (!config?.options?.length) return null;
     const mainOption = config.options.find((o) => o.value?.anchorName === 'main');
-    return mainOption?.value?.anchorRef ? JSON.stringify(mainOption.value.anchorRef) : null;
+    return mainOption?.value?.anchorRef ?? null;
   });
 
   // Computed preset value for watching
   const currentPreset = computed(() => getPreset?.() ?? 'none');
 
   // Track the last known anchor to detect actual anchor changes
-  const lastKnownAnchor = ref<PlRef | null>(null);
+  const lastKnownAnchor = ref<ColumnUniversalId | null>(null);
 
   // Watch inputAnchor, config's anchor key, and preset
   watch(
     [getAnchor, configAnchorKey, currentPreset],
-    ([currentAnchor, configKey, preset]: [PlRef | undefined, string | null, string]) => {
+    ([currentAnchor, _configKey, preset]: [ColumnUniversalId | undefined, ColumnUniversalId | null, string]) => {
       const config = getConfig();
       // Include preset in anchor key so changing preset invalidates "already initialized"
       const presetSuffix = getPreset ? `::${getPreset() ?? 'none'}` : '';
-      const currentAnchorKey = currentAnchor ? JSON.stringify(currentAnchor) + presetSuffix : null;
+      const currentAnchorKey = currentAnchor ? `${currentAnchor}${presetSuffix}` : null;
       const initializedAnchorKey = getInitializedAnchorKey?.();
       const isAlreadyInitialized = currentAnchorKey && initializedAnchorKey === currentAnchorKey;
 
@@ -98,7 +97,7 @@ export function useAnchorSyncedDefaults(options: UseAnchorSyncedDefaultsOptions)
       }
 
       // Already applied for this anchor+preset combo (in this component instance)? Skip
-      if (appliedForAnchor.value && plRefsEqual(appliedForAnchor.value, currentAnchor)
+      if (appliedForAnchor.value && appliedForAnchor.value === currentAnchor
         && appliedForPreset.value === preset) {
         return;
       }
@@ -114,13 +113,13 @@ export function useAnchorSyncedDefaults(options: UseAnchorSyncedDefaultsOptions)
 
       // No config yet - wait for config before making decisions
       // If we have existing items, preserve them until config confirms anchor change
-      if (!config || !configKey) {
+      if (!config || !_configKey) {
         // If there are existing items, don't clear - wait for config to confirm
         if (hasAnyItems?.()) {
           return;
         }
         // No existing items - only clear tracking if anchor actually changed
-        const anchorActuallyChanged = !lastKnownAnchor.value || !plRefsEqual(lastKnownAnchor.value, currentAnchor);
+        const anchorActuallyChanged = !lastKnownAnchor.value || lastKnownAnchor.value !== currentAnchor;
         if (anchorActuallyChanged) {
           appliedForAnchor.value = null;
           appliedForPreset.value = null;
@@ -131,9 +130,9 @@ export function useAnchorSyncedDefaults(options: UseAnchorSyncedDefaultsOptions)
 
       // Verify config matches current anchor BEFORE checking defaults
       const mainOption = config.options?.find((o) => o.value?.anchorName === 'main');
-      if (!mainOption?.value || !plRefsEqual(mainOption.value.anchorRef, currentAnchor)) {
+      if (!mainOption?.value || mainOption.value.anchorRef !== currentAnchor) {
         // Config is stale - only clear if anchor actually changed
-        const anchorActuallyChanged = !lastKnownAnchor.value || !plRefsEqual(lastKnownAnchor.value, currentAnchor);
+        const anchorActuallyChanged = !lastKnownAnchor.value || lastKnownAnchor.value !== currentAnchor;
         if (anchorActuallyChanged) {
           clearState();
           appliedForAnchor.value = null;
@@ -149,7 +148,7 @@ export function useAnchorSyncedDefaults(options: UseAnchorSyncedDefaultsOptions)
       // Check if existing state matches current config (e.g., after component remount)
       // This must be done AFTER we have valid config to compare against
       // Skip this check when preset changed — user explicitly wants new defaults
-      const presetChanged = appliedForAnchor.value && plRefsEqual(appliedForAnchor.value, currentAnchor)
+      const presetChanged = appliedForAnchor.value && appliedForAnchor.value === currentAnchor
         && appliedForPreset.value !== preset;
       if (!presetChanged && hasExistingStateForConfig?.(config)) {
         appliedForAnchor.value = currentAnchor;

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { PlMultiSequenceAlignment } from '@milaboratories/multi-sequence-alignment';
 import strings from '@milaboratories/strings';
-import { getInputAnchorRef } from '@platforma-open/milaboratories.top-antibodies.model';
-import type { PlRef, PlSelectionModel } from '@platforma-sdk/model';
+import { getInputAnchorId } from '@platforma-open/milaboratories.top-antibodies.model';
+import type { ColumnUniversalId, PlSelectionModel } from '@platforma-sdk/model';
 import { createPlDataTableStateV2 } from '@platforma-sdk/model';
 import {
   PlAgDataTableV2,
@@ -29,12 +29,12 @@ import RankList from './components/RankList.vue';
 
 const app = useApp();
 
-// Current primary anchor PlRef extracted from the DatasetSelection. Watchers
-// and downstream lookups all key off this — `data.input` is the opaque payload,
+// Canonical ColumnUniversalId for the current primary anchor. Watchers and
+// downstream lookups all key off this — `data.input` is the opaque payload,
 // but the existing block logic still thinks in terms of "the anchor".
-const inputAnchorRef = computed(() => getInputAnchorRef(app.model.data));
+const inputAnchorId = computed(() => getInputAnchorId(app.model.data));
 
-const settingsOpen = ref(inputAnchorRef.value === undefined);
+const settingsOpen = ref(inputAnchorId.value === undefined);
 const multipleSequenceAlignmentOpen = ref(false);
 
 // Watch for when the workflow starts running and close settings
@@ -78,36 +78,36 @@ const kabatNumbering = computed<boolean>({
 // Special value for "No diversification" option
 const NO_DIVERSIFICATION_VALUE = '__no_diversification__';
 
-// Cluster column options with "No diversification" prepended
-// Transform ref-based options to value-based options using JSON.stringify
+// Cluster column options with "No diversification" prepended. Each option's
+// `id` is already a `ColumnUniversalId` (string), so it can be used directly
+// as the dropdown value — no JSON dance needed.
 const clusterColumnOptionsWithNone = computed(() => {
   const options = app.model.outputs.clusterColumnOptions ?? [];
   return [
     { label: 'No diversification (allow similar sequences)', value: NO_DIVERSIFICATION_VALUE },
     ...options.map((o) => ({
       label: o.label,
-      value: JSON.stringify(o.ref),
+      value: o.id,
     })),
   ];
 });
 
-// Selected cluster column value for the dropdown
+// Selected cluster column value for the dropdown. The dropdown sentinel is a
+// plain string; real cluster IDs come from `clusterColumnOptions` and are
+// already typed as `ColumnUniversalId`.
 const selectedClusterColumnValue = computed<string | undefined>({
-  get: () => {
-    if (!app.model.data.diversificationColumn) return NO_DIVERSIFICATION_VALUE;
-    return JSON.stringify(app.model.data.diversificationColumn);
-  },
+  get: () => app.model.data.diversificationColumn ?? NO_DIVERSIFICATION_VALUE,
   set: (v: string | undefined) => {
     app.model.data.diversificationColumn
-        = (v === NO_DIVERSIFICATION_VALUE || v === undefined) ? undefined : JSON.parse(v) as PlRef;
+        = (v === NO_DIVERSIFICATION_VALUE || v === undefined) ? undefined : (v as ColumnUniversalId);
   },
 });
 
 // Clear diversificationColumn when inputAnchor changes (old value is invalid for new dataset)
 watch(
-  inputAnchorRef,
+  inputAnchorId,
   (newAnchor, oldAnchor) => {
-    if (oldAnchor && newAnchor && JSON.stringify(oldAnchor) !== JSON.stringify(newAnchor)) {
+    if (oldAnchor && newAnchor && oldAnchor !== newAnchor) {
       app.model.data.diversificationColumn = undefined;
     }
   },
@@ -118,7 +118,7 @@ watch(
   () => app.model.outputs.clusterColumnOptions,
   (options) => {
     if (options && options.length > 0 && !app.model.data.diversificationColumn) {
-      app.model.data.diversificationColumn = options[0].ref;
+      app.model.data.diversificationColumn = options[0].id;
     }
   },
   { immediate: true },
@@ -152,7 +152,7 @@ const selectedPresetValue = computed<string>({
 
 // Reset preset when inputAnchor or modality changes (clears stale presets when
 watch(
-  [inputAnchorRef, () => app.model.outputs.modality],
+  [inputAnchorId, () => app.model.outputs.modality],
   () => {
     app.model.data.preset = undefined;
   },
@@ -192,7 +192,7 @@ watch(() => app.model.data.topClonotypes, (newVal) => {
 });
 
 // Reset table state when dataset or Kabat toggle changes to re-apply defaults (like optional visibility)
-watch(() => [inputAnchorRef.value, app.model.data.kabatNumbering], () => {
+watch(() => [inputAnchorId.value, app.model.data.kabatNumbering], () => {
   app.model.data.tableState = createPlDataTableStateV2();
 });
 </script>

--- a/ui/src/pages/components/FilterList.vue
+++ b/ui/src/pages/components/FilterList.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { DiscreteFilter, FilterUI, PlTableFilter, ScopedColumnId } from '@platforma-open/milaboratories.top-antibodies.model';
-import { getInputAnchorRef } from '@platforma-open/milaboratories.top-antibodies.model';
+import { getInputAnchorId } from '@platforma-open/milaboratories.top-antibodies.model';
 import { PlBtnSecondary, PlElementList, PlIcon16, PlRow, PlTooltip } from '@platforma-sdk/ui-vue';
 import { ref } from 'vue';
 import { useApp } from '../../app';
@@ -61,7 +61,7 @@ const resetToDefaults = () => {
 
 // Use shared anchor sync logic
 useAnchorSyncedDefaults({
-  getAnchor: () => getInputAnchorRef(app.model.data),
+  getAnchor: () => getInputAnchorId(app.model.data),
   getConfig: () => app.model.outputs.filterConfig,
   clearState: () => {
     app.model.data.filters = [];

--- a/ui/src/pages/components/RankList.vue
+++ b/ui/src/pages/components/RankList.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { ScopedColumnId } from '@platforma-open/milaboratories.top-antibodies.model';
-import { getInputAnchorRef } from '@platforma-open/milaboratories.top-antibodies.model';
+import { getInputAnchorId } from '@platforma-open/milaboratories.top-antibodies.model';
 import { PlBtnSecondary, PlElementList, PlIcon16, PlRow, PlTooltip } from '@platforma-sdk/ui-vue';
 import { ref } from 'vue';
 import { useApp } from '../../app';
@@ -61,7 +61,7 @@ const resetToDefaults = () => {
 
 // Use shared anchor sync logic
 useAnchorSyncedDefaults({
-  getAnchor: () => getInputAnchorRef(app.model.data),
+  getAnchor: () => getInputAnchorId(app.model.data),
   getConfig: () => app.model.outputs.rankingConfig,
   clearState: () => {
     app.model.data.rankingOrder = [];


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This draft PR migrates the block from the legacy `PlRef`/`resultPool` column-access API to the new `ColumnUniversalId`/`ColumnsCollection`/`Column()` API, adding a `Ver_2026_05_28` data-migration step to convert the stored `diversificationColumn` field from `PlRef` to `ColumnUniversalId`.

- **Model layer**: New migration step converts `diversificationColumn` from `PlRef` to `ColumnUniversalId` via `createGlobalPObjectId`; `BlockData_Ver_2026_05_21` frozen snapshot added; all internal types (`BlockArgs`, `ScopedColumnId`, `ColumnsMeta`) updated to use `ColumnRecipe`/`ColumnUniversalId`.
- **Index/util**: `buildCollection`, `filterConfig`, `rankingConfig`, `table`, `pf`, `umapPf`, `umapPcols` and related helpers fully ported to selector-based discovery (`ColumnsCollection`, `Column()`); lambda predicates replaced with `RelaxedColumnSelector` objects; `getInputAnchorId`/`getInputFilterId` added alongside the legacy `getInputAnchorRef`.
- **UI**: `PlRef`/`plRefsEqual` replaced with `ColumnUniversalId` string comparisons throughout `useAnchorSyncedDefaults`, `MainPage.vue`, `FilterList.vue`, and `RankList.vue`; local file dependency overrides committed to `package.json` and `pnpm-lock.yaml` (development-only, must be reverted before merge).
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge as-is: the committed `package.json` and `pnpm-lock.yaml` reference developer-local tarballs that will break any build environment without the matching sibling directory.

The SDK migration logic itself is well-structured and the migration chain is correctly sequenced. However, the dependency overrides in `package.json` and `pnpm-lock.yaml` point to local paths (`../platforma_1/…`) that only exist on the author's machine. Additionally, the index-based pairing of `deriveDistinctLabels` output with the `columns`/`rankable` arrays in `filterConfig` and `rankingConfig` relies on an undocumented length-preservation guarantee from the SDK function. Both issues need to be addressed before this is ready to land.

`package.json` and `pnpm-lock.yaml` need the local file overrides reverted; `model/src/index.ts` filterConfig/rankingConfig option-building logic needs the index-alignment assumption verified or made explicit.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| model/src/dataModel.ts | Adds a new Ver_2026_05_28 migration step that converts `diversificationColumn` from `PlRef` to `ColumnUniversalId`; corrects the Ver_2026_05_21 return type annotation from `BlockData` to `BlockData_Ver_2026_05_21`. |
| model/src/types.ts | Adds `BlockData_Ver_2026_05_21` as a frozen intermediate snapshot; rewires `BlockData` to extend it with `diversificationColumn?: ColumnUniversalId`; updates `BlockArgs`, `ScopedColumn`, `ScopedColumnId`, and `ColumnsMeta` to use `ColumnRecipe` / `ColumnUniversalId` throughout. |
| model/src/util.ts | Replaces `ColumnCollectionBuilder`/`AnchoredColumnCollection` with `ColumnsCollection`; adds `getInputAnchorId`/`getInputFilterId` helpers; expands `commonExcludeSelectors`; replaces `isSelectableMatch` and `matchToColumnId` with selector-based equivalents. |
| model/src/index.ts | Large migration from `resultPool` / lambda-based column discovery to `Column()` / `ColumnsCollection()` / selector-based API; introduces `recipesToPColumns` and `filterRankSelectors` helpers; index-based alignment between `deriveDistinctLabels` output and column arrays is fragile. |
| package.json | Adds `pnpm.overrides` pointing all SDK packages to local `file:../platforma_1/` paths — these will break CI and any build environment that does not have that sibling directory. |
| pnpm-lock.yaml | Lock file updated to reflect local file overrides; resolution entries for all SDK packages now point to developer-local tarball paths, making the lock file non-portable. |
| ui/src/composables/useAnchorSyncedDefaults.ts | Replaces `PlRef` with `ColumnUniversalId` (string type); removes `plRefsEqual` comparisons in favour of `===`; simplifies `configAnchorKey` extraction by dropping the intermediate `JSON.stringify`. |
| ui/src/pages/MainPage.vue | Replaces `getInputAnchorRef` with `getInputAnchorId`; removes JSON.stringify/parse dance for `diversificationColumn`; all watchers and computed refs updated to use the new string ID. |
| ui/src/pages/components/FilterList.vue | One-line swap of `getInputAnchorRef` → `getInputAnchorId` in the `useAnchorSyncedDefaults` call. |
| ui/src/pages/components/RankList.vue | One-line swap of `getInputAnchorRef` → `getInputAnchorId` in the `useAnchorSyncedDefaults` call. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Stored data (disk)"] --> B{Migration chain}
    B --> C["Ver_2026_02_25\n(PlRef anchors)"]
    C --> D["Ver_2026_05_08\n(+ selectionPlotState)"]
    D --> E["Ver_2026_05_21\n(inputAnchor → DatasetSelection)"]
    E --> F["Ver_2026_05_28 ★ NEW\n(diversificationColumn: PlRef → ColumnUniversalId)"]
    F --> G["BlockData (current)\ndiversificationColumn: ColumnUniversalId"]
    G --> H["getInputAnchorId()\ncreateGlobalPObjectId(blockId, name)"]
    H --> I["ColumnsCollection / Column()\nnew selector-based API"]
    I --> J["filterConfig / rankingConfig\nderiveDistinctLabels → options"]
    I --> K["table output\nprimaryColumns + columns"]
    I --> L["pf / umapPf / spectratypePf\ncreateP Frame with IDs"]
    G --> M["BlockArgs.inputAnchor\nColumnUniversalId"]
    M --> N["Workflow engine"]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `model/src/index.ts`, line 220-227 ([link](https://github.com/platforma-open/antibody-tcr-lead-selection/blob/aeebe9c257e895553c3fd828a3d8edc3b7628e34/model/src/index.ts#L220-L227)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Index alignment between `deriveDistinctLabels` output and `columns` array is fragile**

   The code maps `labeled[i]` → `columns[i]` assuming `deriveDistinctLabels` returns one entry per input spec (i.e., same length, same order). If the function ever deduplicates or drops an entry (which "distinct" in the name might imply), `columns[i]` would silently resolve to the wrong column, producing a mismatched label/value pair in the dropdown. The same pattern is repeated for `rankingConfig` a few lines below. A safer approach would be to return `{ label, recipe }` pairs so the pairing is explicit.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: model/src/index.ts
   Line: 220-227

   Comment:
   **Index alignment between `deriveDistinctLabels` output and `columns` array is fragile**

   The code maps `labeled[i]` → `columns[i]` assuming `deriveDistinctLabels` returns one entry per input spec (i.e., same length, same order). If the function ever deduplicates or drops an entry (which "distinct" in the name might imply), `columns[i]` would silently resolve to the wrong column, producing a mismatched label/value pair in the dropdown. The same pattern is repeated for `rankingConfig` a few lines below. A safer approach would be to return `{ label, recipe }` pairs so the pairing is explicit.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
package.json:22-32
**Local file overrides will break CI and teammates' builds**

The new `pnpm.overrides` block points all SDK dependencies to paths under `../platforma_1/`, which is a developer-local sibling directory. Any machine that does not have that directory structure — including every CI runner and every other team member — will fail to install dependencies entirely. The matching `pnpm-lock.yaml` changes bake these local resolutions into the lock file, making the problem repeatable for anyone who pulls the branch.

These overrides should be removed (or kept only in a gitignored local config) before this branch is merged.

### Issue 2 of 3
model/src/index.ts:220-227
**Index alignment between `deriveDistinctLabels` output and `columns` array is fragile**

The code maps `labeled[i]` → `columns[i]` assuming `deriveDistinctLabels` returns one entry per input spec (i.e., same length, same order). If the function ever deduplicates or drops an entry (which "distinct" in the name might imply), `columns[i]` would silently resolve to the wrong column, producing a mismatched label/value pair in the dropdown. The same pattern is repeated for `rankingConfig` a few lines below. A safer approach would be to return `{ label, recipe }` pairs so the pairing is explicit.

### Issue 3 of 3
model/src/index.ts:363-365
**`umapPf` and `umapPcols` outputs duplicate the same discovery/collection block**

Both `umapPf` and `umapPcols` perform identical anchor-spec lookup, `ColumnsCollection` discovery, and `sampledRows` resolution. If the logic in one is changed it must be manually replicated in the other, which is error-prone. Extracting a shared helper (similar to `buildCollection`) would eliminate the duplication and reduce the surface for future drift.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: update column handling logic t..."](https://github.com/platforma-open/antibody-tcr-lead-selection/commit/aeebe9c257e895553c3fd828a3d8edc3b7628e34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37603683)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->