### PR TITLE
MILAB-6413: add convergence freq/hit to in-vivo preset defaults

### DIFF
--- a/.changeset/convergence-in-vivo-defaults.md
+++ b/.changeset/convergence-in-vivo-defaults.md
@@ -1,0 +1,11 @@
+---
+'@platforma-open/milaboratories.top-antibodies.model': patch
+---
+
+Add clonotype-convergence columns to the in-vivo preset defaults. Convergent
+neighbour frequency (`pl7.app/vdj/convergence/nbFreq`) joins the default
+in-vivo ranking (descending), and convergent hit
+(`pl7.app/vdj/convergence/fastStar`) joins the default in-vivo filters (keep
+only "Hit"). Effective when the convergence columns carry the matching
+`pl7.app/isScore` / `pl7.app/score/defaultCutoff` annotations (emitted by the
+clonotype-convergence block).

--- a/model/src/util.ts
+++ b/model/src/util.ts
@@ -72,6 +72,8 @@ export const IN_VIVO_FILTER_SPEC_NAMES = new Set([
   'pl7.app/vdj/isProductive',
   'pl7.app/developabilityRisk',
   'pl7.app/vdj/developabilityRisk',
+  // Convergent hit (clonotype-convergence) — default "keep only Hit" filter.
+  'pl7.app/vdj/convergence/fastStar',
 ]);
 
 // In Vivo preset allowlist for ranking. The In Vivo Score sentinel is added
@@ -79,6 +81,8 @@ export const IN_VIVO_FILTER_SPEC_NAMES = new Set([
 export const IN_VIVO_RANKING_SPEC_NAMES = new Set([
   'pl7.app/developabilityScore',
   'pl7.app/vdj/developabilityScore',
+  // Convergent neighbour frequency (clonotype-convergence) — ranked descending.
+  'pl7.app/vdj/convergence/nbFreq',
 ]);
 
 // In Vitro preset allowlists. Same intersection-with-discovery approach as


### PR DESCRIPTION
nbFreq -> IN_VIVO_RANKING_SPEC_NAMES (default in-vivo ranking, descending); fastStar -> IN_VIVO_FILTER_SPEC_NAMES (default in-vivo filter, keep only Hit). Effective once the convergence columns carry isScore / defaultCutoff, which the clonotype-convergence block now emits.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends two in-vivo preset allowlists in `model/src/util.ts` with the new clonotype-convergence columns, and ships a matching changeset entry. The additions are gated by the upstream block's `isScore`/`defaultCutoff` annotations, so they are entirely inert until the convergence block emits them.

- `pl7.app/vdj/convergence/fastStar` added to `IN_VIVO_FILTER_SPEC_NAMES` — will produce a "keep only Hit" default filter once the column carries the required annotations.
- `pl7.app/vdj/convergence/nbFreq` added to `IN_VIVO_RANKING_SPEC_NAMES` — will appear in the default descending ranking once the column carries `isScore=true`.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is purely additive — new spec names in two allowlist Sets have zero effect until the convergence block upstream emits matching annotations, so no existing behaviour is disturbed.

Both additions are guarded by the existing `isScore`/`defaultCutoff` annotation pipeline; there is no logic change, only a whitelist expansion. The one open question is whether unprefixed variants of the convergence spec names should also be listed, consistent with how other multi-version columns are handled — but that is a forward-compatibility concern, not a current defect.

model/src/util.ts — specifically the decision on whether `pl7.app/convergence/fastStar` and `pl7.app/convergence/nbFreq` (without the `vdj/` prefix) need to be added for future peptide-adapted convergence block versions.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| model/src/util.ts | Adds `pl7.app/vdj/convergence/fastStar` to `IN_VIVO_FILTER_SPEC_NAMES` and `pl7.app/vdj/convergence/nbFreq` to `IN_VIVO_RANKING_SPEC_NAMES`; both are allowlist-only additions so they have no effect until the upstream convergence block emits matching `isScore`/`defaultCutoff` annotations. Missing unprefixed variants may be worth considering if a post-adaptation block ever strips the `vdj/` prefix. |
| .changeset/convergence-in-vivo-defaults.md | New changeset entry correctly classifies the bump as a `patch` and accurately documents the two new allowlist entries and their activation condition. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildCollection] --> B[computeDefaultFilters\nscores with isScore=true AND defaultCutoff]
    A --> C[computePresets]
    B --> D{valueType?}
    D -- String --> E[string_in / string_equals filter]
    D -- Numeric --> F[number_gte / number_lte filter]
    C --> G[inVivoFilters\nIntersect with IN_VIVO_FILTER_SPEC_NAMES]
    C --> H[inVivoRankingOrder\nIntersect with IN_VIVO_RANKING_SPEC_NAMES]
    G --> G1["✅ fastStar → string filter\n'keep only Hit'"]
    H --> H1["✅ nbFreq → descending rank"]
    B --> G
    B --> H
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[buildCollection] --> B[computeDefaultFilters\nscores with isScore=true AND defaultCutoff]
    A --> C[computePresets]
    B --> D{valueType?}
    D -- String --> E[string_in / string_equals filter]
    D -- Numeric --> F[number_gte / number_lte filter]
    C --> G[inVivoFilters\nIntersect with IN_VIVO_FILTER_SPEC_NAMES]
    C --> H[inVivoRankingOrder\nIntersect with IN_VIVO_RANKING_SPEC_NAMES]
    G --> G1["✅ fastStar → string filter\n'keep only Hit'"]
    H --> H1["✅ nbFreq → descending rank"]
    B --> G
    B --> H
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `model/src/util.ts`, line 71-86 ([link](https://github.com/platforma-open/antibody-tcr-lead-selection/blob/16db3ce458377ee3e1d1fdec5efe6b90e59afde9/model/src/util.ts#L71-L86)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing unprefixed variants for convergence spec names**

   Every other multi-version column in these two sets has a paired unprefixed entry to cover post-peptide-adaptation upstreams (e.g. `pl7.app/developabilityRisk` alongside `pl7.app/vdj/developabilityRisk`). The convergence entries land only under the `pl7.app/vdj/convergence/` prefix. If a future peptide-adapted block emits `pl7.app/convergence/fastStar` or `pl7.app/convergence/nbFreq`, neither the filter nor the ranking default will fire for it. Worth deciding now whether to add both variants (consistent with the pattern) or to document that convergence columns will always keep the `vdj/` prefix.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: model/src/util.ts
   Line: 71-86

   Comment:
   **Missing unprefixed variants for convergence spec names**

   Every other multi-version column in these two sets has a paired unprefixed entry to cover post-peptide-adaptation upstreams (e.g. `pl7.app/developabilityRisk` alongside `pl7.app/vdj/developabilityRisk`). The convergence entries land only under the `pl7.app/vdj/convergence/` prefix. If a future peptide-adapted block emits `pl7.app/convergence/fastStar` or `pl7.app/convergence/nbFreq`, neither the filter nor the ranking default will fire for it. Worth deciding now whether to add both variants (consistent with the pattern) or to document that convergence columns will always keep the `vdj/` prefix.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
model/src/util.ts:71-86
**Missing unprefixed variants for convergence spec names**

Every other multi-version column in these two sets has a paired unprefixed entry to cover post-peptide-adaptation upstreams (e.g. `pl7.app/developabilityRisk` alongside `pl7.app/vdj/developabilityRisk`). The convergence entries land only under the `pl7.app/vdj/convergence/` prefix. If a future peptide-adapted block emits `pl7.app/convergence/fastStar` or `pl7.app/convergence/nbFreq`, neither the filter nor the ranking default will fire for it. Worth deciding now whether to add both variants (consistent with the pattern) or to document that convergence columns will always keep the `vdj/` prefix.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6413: add convergence freq/hit to ..."](https://github.com/platforma-open/antibody-tcr-lead-selection/commit/16db3ce458377ee3e1d1fdec5efe6b90e59afde9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37925070)</sub>

<!-- /greptile_comment -->