### PR TITLE
Julenmendieta/MILAB-6356_embeddingClusteringTrace

### DIFF
--- a/.changeset/ten-buttons-watch.md
+++ b/.changeset/ten-buttons-watch.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.top-antibodies.model": patch
+---
+
+Include embedding clustering trace

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -42,6 +42,7 @@ export type BlockOutputs = InferOutputsType<typeof platforma>;
 const CLUSTERING_TRACE_TYPES = [
   'milaboratories.clonotype-clustering.clustering',
   'milaboratories.3d-structure-clustering.clustering',
+  'milaboratories.embedding-clustering.clustering',
 ];
 
 export const platforma = BlockModelV3.create(blockDataModel)


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the lead-selection model to recognise the embedding-clustering block as a valid upstream clustering source by adding its trace type to `CLUSTERING_TRACE_TYPES`.

**Key terms touched:**

- **`CLUSTERING_TRACE_TYPES`** (`model/src/index.ts`, line 42): A constant string array listing every trace-element type emitted by upstream clustering producers. It gates both the `forceTraceElements` hint passed to `resultPool.getOptions()` and the `trace.find()` call that extracts a human-readable label for the cluster-column dropdown. This PR appends `'milaboratories.embedding-clustering.clustering'` so that linker columns produced by the embedding-clustering block are surfaced and correctly labelled.

- **`clusterColumnOptions`** (output, line 549): The model output that iterates linker columns, filters to those with a `clusterId` axis, and uses `CLUSTERING_TRACE_TYPES` to pull the matching trace-element label. With the new entry in the array, embedding-clustering linkers will now appear in this output and carry the correct label instead of falling back to `\"Cluster\"`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single-line addition to a well-commented registry array with no logic changes.

The diff is a one-line string addition to CLUSTERING_TRACE_TYPES that follows the established naming pattern. Both consumers of the array (forceTraceElements hint and trace.find() label extraction) handle new entries transparently, so there is no risk of regression to existing clustering types. The changeset file is correctly scoped as a patch.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model/src/index.ts | Adds 'milaboratories.embedding-clustering.clustering' to CLUSTERING_TRACE_TYPES, extending cluster label lookup and trace element extraction to support the new embedding-clustering producer. |
| .changeset/ten-buttons-watch.md | Changeset file marking a patch bump for the model package with the description "Include embedding clustering trace". |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Upstream Clustering Block\n(milaboratories.embedding-clustering)"] -->|"emits trace with type\n'milaboratories.embedding-clustering.clustering'"| B["Result Pool\n(linker columns with pl7.app/trace)"]
    B --> C["clusterColumnOptions output\nctx.resultPool.getOptions()\nforceTraceElements: CLUSTERING_TRACE_TYPES"]
    C --> D{"trace.find(t =>\nCLUSTERING_TRACE_TYPES\n.includes(t.type))"}
    D -->|"match found → use t.label"| E["options.push({ label, ref })"]
    D -->|"no match → use default 'Cluster'"| E
    E --> F["Cluster Column Dropdown\nin Lead-Selection UI"]

    subgraph CLUSTERING_TRACE_TYPES ["CLUSTERING_TRACE_TYPES (after this PR)"]
        G["milaboratories.clonotype-clustering.clustering"]
        H["milaboratories.3d-structure-clustering.clustering"]
        I["milaboratories.embedding-clustering.clustering NEW"]
    end

    CLUSTERING_TRACE_TYPES --> C
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Upstream Clustering Block\n(milaboratories.embedding-clustering)"] -->|"emits trace with type\n'milaboratories.embedding-clustering.clustering'"| B["Result Pool\n(linker columns with pl7.app/trace)"]
    B --> C["clusterColumnOptions output\nctx.resultPool.getOptions()\nforceTraceElements: CLUSTERING_TRACE_TYPES"]
    C --> D{"trace.find(t =>\nCLUSTERING_TRACE_TYPES\n.includes(t.type))"}
    D -->|"match found → use t.label"| E["options.push({ label, ref })"]
    D -->|"no match → use default 'Cluster'"| E
    E --> F["Cluster Column Dropdown\nin Lead-Selection UI"]

    subgraph CLUSTERING_TRACE_TYPES ["CLUSTERING_TRACE_TYPES (after this PR)"]
        G["milaboratories.clonotype-clustering.clustering"]
        H["milaboratories.3d-structure-clustering.clustering"]
        I["milaboratories.embedding-clustering.clustering NEW"]
    end

    CLUSTERING_TRACE_TYPES --> C
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Changeset"](https://github.com/platforma-open/antibody-tcr-lead-selection/commit/25fc14ff3c7fa6c2c15e3c88d679ed8838c6de7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38373521)</sub>

<!-- /greptile_comment -->