### PR TITLE
Fix Lead Selection hiding columns produced downstream of an earlier selection

### DIFF
--- a/.changeset/fix-downstream-lead-selection-columns.md
+++ b/.changeset/fix-downstream-lead-selection-columns.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.top-antibodies.model": patch
+---
+
+Fix columns produced downstream of an earlier Lead Selection (e.g. 3D Structure Prediction / Clustering / 3D Structure-Based Liabilities) being hidden from the ranking, filter and table column pickers. The self-column filter matched `antibody-tcr-lead-selection` anywhere in a column's trace, so it also excluded everything computed after a "Selected Leads" step. It now matches only the producing (last) trace step, so a Lead Selection still hides its own selection-marker columns while surfacing downstream analytical columns such as Developability cost.

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -24,7 +24,7 @@ import {
   isHiddenFromUIColumn,
   isPColumnSpec,
 } from '@platforma-sdk/model';
-import { buildCollection, commonExcludeSelectors, getInputAnchorRef, getInputFilterRef, IN_VIVO_SCORE_COLUMN_ID, isClusterIdAxisName, isSelectableMatch, matchToColumnId } from './util';
+import { buildCollection, commonExcludeSelectors, getInputAnchorRef, getInputFilterRef, IN_VIVO_SCORE_COLUMN_ID, isClusterIdAxisName, isProducedByLeadSelection, isSelectableMatch, matchToColumnId } from './util';
 import { convertFilterUI, convertRankingOrderUI } from './converters';
 import { blockDataModel } from './dataModel';
 import type { BlockArgs } from './types';
@@ -334,7 +334,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
     const resultPoolColumns = ctx.resultPool.selectColumns(
       (spec) => (spec.valueType as string) !== 'File'
         && !(spec.annotations?.['pl7.app/isLinkerColumn'] === 'true' && spec.axesSpec.length > 2)
-        && !spec.annotations?.[Annotation.Trace]?.includes('antibody-tcr-lead-selection'),
+        && !isProducedByLeadSelection(spec),
     );
     const sources: ColumnSource[] = [
       new ArrayColumnProvider(resultPoolColumns),

--- a/model/src/util.ts
+++ b/model/src/util.ts
@@ -1,6 +1,6 @@
 import {
   Annotation,
-  ColumnCollectionBuilder, type AnchoredColumnCollection,
+  ColumnCollectionBuilder, readAnnotationJson, type AnchoredColumnCollection,
   type AnchoredFindColumnsOptions,
   type AxisSpec,
   type ColumnMatch,
@@ -36,13 +36,27 @@ export const CLUSTER_ID_AXIS_NAMES: ReadonlySet<string> = new Set([
 ]);
 export const isClusterIdAxisName = (name: string): boolean => CLUSTER_ID_AXIS_NAMES.has(name);
 
+/** Trace-step `type` stamped by a lead-selection block onto the columns it produces. */
+const LEAD_SELECTION_TRACE_TYPE = 'milaboratories.antibody-tcr-lead-selection';
+
+/** True when the column was produced *by* a lead-selection block, as opposed to merely
+ *  being downstream of one. `pSpec.makeTrace` appends the producing block as the LAST
+ *  trace step, so only the final entry identifies the producer — a substring match on
+ *  the whole trace also (wrongly) catches everything computed downstream of a Selected
+ *  Leads step (3D structure prediction/clustering/liabilities, etc.). */
+export function isProducedByLeadSelection(spec: PColumnSpec): boolean {
+  const trace = readAnnotationJson(spec, Annotation.Trace);
+  return Array.isArray(trace) && trace.length > 0
+    && trace[trace.length - 1]?.type === LEAD_SELECTION_TRACE_TYPE;
+}
+
 /** JS post-filter for column matches — excludes sampleId-axis, cluster mapping, label,
- *  and columns produced by this block. */
+ *  and the selection-marker columns this (or another) lead-selection block produces. */
 export function isSelectableMatch(m: ColumnMatch, sampleAxisName: string): boolean {
   return !m.column.spec.axesSpec.some((a) => a.name === sampleAxisName)
     && !isClusterIdAxisName(m.column.spec.name)
     && m.column.spec.name !== 'pl7.app/label'
-    && !m.column.spec.annotations?.[Annotation.Trace]?.includes('antibody-tcr-lead-selection');
+    && !isProducedByLeadSelection(m.column.spec);
 }
 
 /** Converts a ColumnMatch to a ScopedColumnId for the workflow wire format. */


### PR DESCRIPTION
## Problem

In a project where a Lead Selection feeds the 3D structure pipeline (3D Structure Prediction → Clustering → 3D Structure-Based Liabilities) and then a second Lead Selection, none of the 3D-pipeline columns — `Developability cost`, `Developability risk`, structural liability metrics — appeared in the second Lead Selection's **Ranking / Filter / table** column pickers.

Root cause: the self-column filter excluded any column whose trace string *contained* `antibody-tcr-lead-selection`:

```ts
!spec.annotations?.[Annotation.Trace]?.includes('antibody-tcr-lead-selection')
```

This was meant to hide a Lead Selection's *own* selection-marker columns (`link` / `selectionStage`, both `isSubset`). But because the entire trace lineage is matched, it also excluded everything computed **downstream** of a "Selected Leads" step. Columns produced by `antibody-sequence-liabilities` (which runs straight off Redefine Clonotypes, no lead-selection ancestor) were unaffected — which is why an identically-labeled `Developability cost` from Sequence Liabilities showed up and masked the absence.

## Fix

Match only the **producing** trace step (the last one). `pSpec.makeTrace` appends the producing block's step at the end, so the final entry identifies the producer; a Lead Selection's own columns end in the lead-selection step, while downstream columns end in their own block's step.

- Added `isProducedByLeadSelection(spec)` in `util.ts`, using the SDK `readAnnotationJson(spec, Annotation.Trace)` helper (same one the SDK's label code uses) — typed, no manual `JSON.parse`.
- Replaced both occurrences of the substring check (`util.ts` `isSelectableMatch` and the table-discovery predicate in `index.ts`).

## Effect

- Lead Selection still hides its own (and a sibling selection's) selection-marker columns.
- Columns computed downstream of an earlier selection (3D pipeline, etc.) are now selectable for ranking / filtering / table.

Verified against a live project: the second Lead Selection now lists both `Developability cost` (Sequence Liabilities) and `Developability cost / Selected Leads` (3D Structure-Based Liabilities).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a column-visibility bug where any column **downstream** of a Lead Selection step was incorrectly hidden from the Ranking / Filter / Table column pickers in a subsequent Lead Selection block. The root cause was a substring match on the full trace annotation string, which caught every column whose lineage passed through a lead-selection step, not just the columns that block itself produced.

- **`isProducedByLeadSelection(spec)`** (new, `util.ts`): reads the trace with the typed SDK helper `readAnnotationJson`, then compares only the **last** trace-step `type` to `milaboratories.antibody-tcr-lead-selection`. This correctly distinguishes "I produced this column" from "this column's ancestor was a lead selection".
- **`isSelectableMatch` and `resultPoolColumns`** (`util.ts` / `index.ts`): both old `String.includes` predicates replaced with the new helper, fixing the pickers and the table data pool simultaneously.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a targeted, well-reasoned fix with a small blast radius, and the author has confirmed correct behavior in a live project.

The fix correctly narrows a string-contains predicate to an exact last-step type check, resolving the column-hiding regression. The only uncertainty is that LEAD_SELECTION_TRACE_TYPE is a hard-coded assumption about the SDK's internal block-type format; if the format ever diverges from this constant, lead-selection marker columns would silently reappear in the pickers — but this is a maintenance-time risk, not a present defect.

model/src/util.ts — the new LEAD_SELECTION_TRACE_TYPE constant ties correctness to an undocumented SDK format convention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model/src/util.ts | Adds `isProducedByLeadSelection` using `readAnnotationJson` + last-step check; updates `isSelectableMatch` to call it. Core logic is sound; the constant `LEAD_SELECTION_TRACE_TYPE` is an assumption about the SDK's internal trace-step type format. |
| model/src/index.ts | Imports and substitutes `isProducedByLeadSelection` in the `resultPoolColumns` predicate; mechanical replacement, no logic change beyond fixing the same substring-match bug in the table data pool. |
| .changeset/fix-downstream-lead-selection-columns.md | New changeset entry describing the patch; content is accurate and complete. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Column in resultPool"] --> B{{"isProducedByLeadSelection(spec)"}}
    B --> C["readAnnotationJson(spec, Annotation.Trace)"]
    C --> D{{"trace exists\n&& trace.length > 0?"}}
    D -- No --> E["return false\n→ column is visible"]
    D -- Yes --> F{{"trace[last].type ===\n'milaboratories.antibody-tcr-lead-selection'?"}}
    F -- Yes --> G["return true\n→ column is hidden\n(own selection-marker)"]
    F -- No --> H["return false\n→ column is visible\n(downstream column)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Column in resultPool"] --> B{{"isProducedByLeadSelection(spec)"}}
    B --> C["readAnnotationJson(spec, Annotation.Trace)"]
    C --> D{{"trace exists\n&& trace.length > 0?"}}
    D -- No --> E["return false\n→ column is visible"]
    D -- Yes --> F{{"trace[last].type ===\n'milaboratories.antibody-tcr-lead-selection'?"}}
    F -- Yes --> G["return true\n→ column is hidden\n(own selection-marker)"]
    F -- No --> H["return false\n→ column is visible\n(downstream column)"]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Amodel%2Fsrc%2Futil.ts%3A39-40%0AThe%20%60LEAD_SELECTION_TRACE_TYPE%60%20constant%20hard-codes%20the%20assumption%20that%20the%20SDK's%20%60makeTrace%60%20stamps%20the%20block%20type%20as%20%60'milaboratories.antibody-tcr-lead-selection'%60.%20The%20old%20%60String.includes%60%20check%20used%20%60'antibody-tcr-lead-selection'%60%20%28no%20namespace%20prefix%29%2C%20which%20would%20have%20matched%20both%20%60antibody-tcr-lead-selection%60%20and%20%60milaboratories.antibody-tcr-lead-selection%60.%20If%20the%20framework%20ever%20stamps%20just%20the%20short%20form%2C%20the%20new%20strict%20equality%20check%20would%20silently%20stop%20filtering%20selection-marker%20columns.%20A%20brief%20inline%20comment%20pinning%20this%20to%20the%20framework's%20block-type%20format%20would%20help%20future%20maintainers%20know%20where%20to%20look%20if%20the%20filter%20stops%20working.%0A%0A%60%60%60suggestion%0A%2F**%20Trace-step%20%60type%60%20stamped%20by%20a%20lead-selection%20block%20onto%20the%20columns%20it%20produces.%0A%20*%20%20Must%20match%20the%20block-type%20identifier%20used%20by%20%60pSpec.makeTrace%60%20in%20the%20SDK%20%E2%80%94%0A%20*%20%20i.e.%20the%20fully-qualified%20%60%3Cvendor%3E.%3Cblock-name%3E%60%20form%2C%20NOT%20the%20short%20package%20suffix.%20*%2F%0Aconst%20LEAD_SELECTION_TRACE_TYPE%20%3D%20'milaboratories.antibody-tcr-lead-selection'%3B%0A%60%60%60%0A%0A&repo=platforma-open%2Fantibody-tcr-lead-selection&pr=159&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
model/src/util.ts:39-40
The `LEAD_SELECTION_TRACE_TYPE` constant hard-codes the assumption that the SDK's `makeTrace` stamps the block type as `'milaboratories.antibody-tcr-lead-selection'`. The old `String.includes` check used `'antibody-tcr-lead-selection'` (no namespace prefix), which would have matched both `antibody-tcr-lead-selection` and `milaboratories.antibody-tcr-lead-selection`. If the framework ever stamps just the short form, the new strict equality check would silently stop filtering selection-marker columns. A brief inline comment pinning this to the framework's block-type format would help future maintainers know where to look if the filter stops working.

```suggestion
/** Trace-step `type` stamped by a lead-selection block onto the columns it produces.
 *  Must match the block-type identifier used by `pSpec.makeTrace` in the SDK —
 *  i.e. the fully-qualified `<vendor>.<block-name>` form, NOT the short package suffix. */
const LEAD_SELECTION_TRACE_TYPE = 'milaboratories.antibody-tcr-lead-selection';
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Lead Selection hiding columns produc..."](https://github.com/platforma-open/antibody-tcr-lead-selection/commit/d2055f622e2d0e3d43887b8d11dbb24adbce89a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39581706)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->