### PR TITLE
MILAB-6496: surface VDJ Multiomic Integration provenance in Lead Selection labels

### DIFF
--- a/.changeset/vdjm-provenance-in-labels.md
+++ b/.changeset/vdjm-provenance-in-labels.md
@@ -1,0 +1,8 @@
+---
+'@platforma-open/milaboratories.top-antibodies.model': patch
+'@platforma-open/milaboratories.top-antibodies': patch
+---
+
+Show VDJ Multiomic Integration provenance in the filter and ranking column labels.
+
+Its per-clonotype columns (dominant antigen, per-antigen fractions, restriction index, breadth) share generic names, and label derivation only appends trace steps to disambiguate — the high-importance upstream dataset step won those slots, so the columns showed no sign of coming from VDJ Multiomic Integration. Force-include that block's trace type in the filter/ranking label derivation (the same mechanism already used for clustering columns) so its columns are identifiable.

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -45,6 +45,15 @@ const CLUSTERING_TRACE_TYPES = [
   'milaboratories.embedding-clustering.clustering',
 ];
 
+// Trace types force-included in the filter/ranking column labels so the producing block is always
+// identifiable, even when the column's own name is unique (label derivation otherwise only adds trace
+// steps to disambiguate, and a high-importance upstream dataset step wins those slots). VDJ Multiomic
+// Integration's per-clonotype columns (dominant antigen, per-antigen fractions, restriction index,
+// breadth) share generic names, so without this they show no provenance.
+const FORCED_PROVENANCE_TRACE_TYPES = [
+  'milaboratories.vdj-multiomic-integration',
+];
+
 export const platforma = BlockModelV3.create(blockDataModel)
 
   .args<BlockArgs>((data) => {
@@ -142,7 +151,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
     const labeled = deriveLabels(
       filterableMatches,
       (m) => m.column.spec,
-      { includeNativeLabel: true },
+      { includeNativeLabel: true, forceTraceElements: FORCED_PROVENANCE_TRACE_TYPES },
     );
     const options = labeled.map(({ value, label }) => ({
       label,
@@ -176,7 +185,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
     const labeled = deriveLabels(
       rankableMatches,
       (m) => m.column.spec,
-      { includeNativeLabel: true },
+      { includeNativeLabel: true, forceTraceElements: FORCED_PROVENANCE_TRACE_TYPES },
     );
     const options = labeled.map(({ value, label }) => ({
       label,


### PR DESCRIPTION
## What

Force-include the VDJ Multiomic Integration trace type in the filter and ranking column-label derivation, so its per-clonotype columns are identifiable by origin in the filter/ranking pickers.

## Why

VDJ Multiomic Integration's per-clonotype columns (dominant antigen, per-antigen fractions, restriction index, breadth) have generic names. `deriveLabels` only appends a trace step to a label when it's needed to disambiguate same-named columns, and the high-importance upstream dataset step wins those slots — so these columns showed no sign of coming from VDJ Multiomic Integration.

This adds a `FORCED_PROVENANCE_TRACE_TYPES` list (currently just `milaboratories.vdj-multiomic-integration`), passed as `forceTraceElements` to both the filter and ranking `deriveLabels` calls — the same mechanism already used for clustering columns (`CLUSTERING_TRACE_TYPES`).

## Scope

- `model/src/index.ts`: the constant + two `deriveLabels` calls.
- Changeset: patch bump to model + root block.

Companion to platforma-open/vdj-multiomic-integration#1. The provenance only surfaces once VDJ Multiomic Integration columns are present downstream, so this is safe to land independently.
