### PR TITLE
Release software

### DIFF
--- a/.changeset/release-software.md
+++ b/.changeset/release-software.md
@@ -1,0 +1,11 @@
+---
+"@platforma-open/milaboratories.top-antibodies": patch
+"@platforma-open/milaboratories.top-antibodies.anarci-kabat": patch
+"@platforma-open/milaboratories.top-antibodies.assembling-fasta": patch
+"@platforma-open/milaboratories.top-antibodies.sample-clonotypes": patch
+"@platforma-open/milaboratories.top-antibodies.spectratype": patch
+"@platforma-open/milaboratories.top-antibodies.umap": patch
+"@platforma-open/milaboratories.top-antibodies.workflow": patch
+---
+
+Release software


### PR DESCRIPTION
Bumps the block and its software packages (anarci-kabat, assembling-fasta, sample-clonotypes, spectratype, umap) + workflow to publish a new software version. No SDK change.