### PR TITLE
Fix: publish software to trusted registry (block-tools 2.12.7)

### DIFF
--- a/.changeset/fix-quay-registry.md
+++ b/.changeset/fix-quay-registry.md
@@ -1,0 +1,11 @@
+---
+"@platforma-open/milaboratories.top-antibodies": patch
+"@platforma-open/milaboratories.top-antibodies.anarci-kabat": patch
+"@platforma-open/milaboratories.top-antibodies.assembling-fasta": patch
+"@platforma-open/milaboratories.top-antibodies.sample-clonotypes": patch
+"@platforma-open/milaboratories.top-antibodies.spectratype": patch
+"@platforma-open/milaboratories.top-antibodies.umap": patch
+"@platforma-open/milaboratories.top-antibodies.workflow": patch
+---
+
+Rebuild software with block-tools 2.12.7 so docker images publish to the trusted `containers.pl-open.science` registry instead of the untrusted `quay.io` (backend rejects quay images).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: ^0.0.3
       version: 0.0.3
     '@platforma-sdk/block-tools':
-      specifier: 2.12.6
-      version: 2.12.6
+      specifier: 2.12.7
+      version: 2.12.7
     '@platforma-sdk/model':
       specifier: 1.79.20
       version: 1.79.20
@@ -98,7 +98,7 @@ importers:
         version: 1.6.0(@types/node@24.9.1)(rollup@4.52.5)(sass-embedded@1.93.2)(sass@1.93.2)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.1)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.6(@types/node@24.9.1)
+        version: 2.12.7(@types/node@24.9.1)
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -128,7 +128,7 @@ importers:
         version: link:../workflow
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.6(@types/node@24.9.1)
+        version: 2.12.7(@types/node@24.9.1)
       '@platforma-sdk/model':
         specifier: 'catalog:'
         version: 1.79.20
@@ -168,7 +168,7 @@ importers:
         version: 1.3.0
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.6(@types/node@24.9.1)
+        version: 2.12.7(@types/node@24.9.1)
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
         version: 1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
@@ -180,7 +180,7 @@ importers:
         version: 1.5.9
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.6(@types/node@24.9.1)
+        version: 2.12.7(@types/node@24.9.1)
 
   software/assembling-fasta:
     devDependencies:
@@ -189,7 +189,7 @@ importers:
         version: 1.5.9
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.6(@types/node@24.9.1)
+        version: 2.12.7(@types/node@24.9.1)
 
   software/sample-clonotypes:
     devDependencies:
@@ -198,7 +198,7 @@ importers:
         version: 1.5.9
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.6(@types/node@24.9.1)
+        version: 2.12.7(@types/node@24.9.1)
 
   software/spectratype:
     devDependencies:
@@ -207,7 +207,7 @@ importers:
         version: 1.5.9
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.6(@types/node@24.9.1)
+        version: 2.12.7(@types/node@24.9.1)
 
   software/umap:
     devDependencies:
@@ -216,7 +216,7 @@ importers:
         version: 1.5.9
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.6(@types/node@24.9.1)
+        version: 2.12.7(@types/node@24.9.1)
 
   test:
     dependencies:
@@ -1653,8 +1653,8 @@ packages:
     resolution: {integrity: sha512-CyekNfqEildNeTrkjAeaWC7ah+skGMb3d/crSZSgCWACPIVQwg2oRZiJliwmJU/ylcTONPDAef7DYOtmfXsgtw==}
     hasBin: true
 
-  '@platforma-sdk/block-tools@2.12.6':
-    resolution: {integrity: sha512-MtsYTCNhCCA9drSihSh5uXUY2/qCNai/ekOX2pw2gtzjHPXPqnin1Wzri0z/2N1wOShXodRItBUglALNJFWUsQ==}
+  '@platforma-sdk/block-tools@2.12.7':
+    resolution: {integrity: sha512-a13K0hcXYf+sgx+07QFjIu2uTeTH5lhHHI1o563kvs9Z5vssU9jn7HFgXgSe6TMjDntERJcGHiGm8nUd4t3FiA==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -8808,7 +8808,7 @@ snapshots:
       - '@types/node'
       - aws-crt
 
-  '@platforma-sdk/block-tools@2.12.6(@types/node@24.9.1)':
+  '@platforma-sdk/block-tools@2.12.7(@types/node@24.9.1)':
     dependencies:
       '@aws-sdk/client-ecr-public': 3.859.0
       '@aws-sdk/client-s3': 3.859.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ catalog:
   '@platforma-sdk/ui-vue': 1.79.20
   '@platforma-sdk/tengo-builder': 4.0.18
   '@platforma-sdk/package-builder': 3.14.1
-  '@platforma-sdk/block-tools': 2.12.6
+  '@platforma-sdk/block-tools': 2.12.7
   '@platforma-sdk/test': 1.79.23
   '@milaboratories/helpers': 1.14.2
   '@milaboratories/graph-maker': 1.4.8


### PR DESCRIPTION
## Problem
The backend rejects antibody's software with:
```
docker image "quay.io/milaboratories/pl-containers:...top-antibodies.sample-clonotypes.filter..." comes from an untrusted registry "quay.io"
```
The software docker images were built with **block-tools 2.12.6**, whose default docker pull-registry is `quay.io` (untrusted). Merely republishing (PR #165) rebuilt them to quay again.

## Fix
Bump **only** `@platforma-sdk/block-tools` 2.12.6 → 2.12.7. Its default release pull-registry is `containers.pl-open.science` (trusted). Verified locally — the regenerated release descriptor for `sample-clonotypes.filter` is:
```json
{"remoteArtifactLocation":"containers.pl-open.science/milaboratories/pl-containers:...sample-clonotypes.filter..."}
```

The changeset republishes all 5 software packages (anarci-kabat, assembling-fasta, sample-clonotypes, spectratype, umap) + workflow so CI rebuilds them onto the trusted registry.

## Scope note
`@platforma-sdk/model` is intentionally kept at 1.79.20 (not upgraded to 1.80.2). A full SDK/model upgrade would require migrating this block's model code to the new column-collection API (runtime match-predicates → declarative selectors), a separate, larger change. This PR only fixes the registry.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `@platforma-sdk/block-tools` from 2.12.6 to 2.12.7 across the entire monorepo to fix a backend rejection caused by Docker images being published to the untrusted `quay.io` registry. Version 2.12.7 defaults to `containers.pl-open.science`, which the Platforma backend recognizes as a trusted registry.

- **`pnpm-workspace.yaml`**: Catalog version for `@platforma-sdk/block-tools` updated from 2.12.6 → 2.12.7; all workspace packages that use `catalog:` pick this up automatically.
- **`pnpm-lock.yaml`**: All eight importer entries and the package resolution/snapshot entries are updated to 2.12.7 with a new SHA-512 integrity hash, consistent with the single catalog bump.
- **`.changeset/fix-quay-registry.md`**: Marks 7 packages (main block, 5 software packages, workflow) as `patch` releases so CI rebuilds and republishes their Docker images via the corrected tooling.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — it is a minimal, focused version bump of a single build-tooling dependency with no runtime logic changes.

The change touches only the build tooling version (block-tools 2.12.6 → 2.12.7), the lockfile, and a changeset file. No application code, business logic, or runtime configuration is modified. The lockfile diff shows all eight workspace entries consistently updated to 2.12.7, the SHA-512 integrity hash is well-formed, and no unrelated dependencies were altered. The changeset correctly lists all affected packages as patch releases, which will trigger CI to rebuild and republish images via the corrected tooling.

No files require special attention. The lockfile update is mechanical and internally consistent.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pnpm-workspace.yaml | Single catalog entry for @platforma-sdk/block-tools updated from 2.12.6 to 2.12.7; straightforward and consistent with the stated fix. |
| pnpm-lock.yaml | All eight workspace importer entries and the package/snapshot resolution updated to block-tools 2.12.7 with a new SHA-512 integrity hash; no other dependencies changed. |
| .changeset/fix-quay-registry.md | New changeset file marking all 7 affected packages as patch releases; description accurately reflects the registry migration motivation. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CI as CI Build
    participant BT as block-tools 2.12.7
    participant Docker as Docker Builder
    participant Reg as containers.pl-open.science (trusted)
    participant Backend as Platforma Backend

    CI->>BT: pnpm build (5 software pkgs + workflow)
    BT->>Docker: Build container image
    Docker-->>BT: Image ready
    BT->>Reg: Push image to trusted registry
    Reg-->>BT: Image published
    BT-->>CI: "Release descriptor with remoteArtifactLocation = containers.pl-open.science/..."
    CI->>Backend: Deploy block with new descriptor
    Backend->>Reg: Pull image (trusted registry)
    Reg-->>Backend: Image pulled successfully
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CI as CI Build
    participant BT as block-tools 2.12.7
    participant Docker as Docker Builder
    participant Reg as containers.pl-open.science (trusted)
    participant Backend as Platforma Backend

    CI->>BT: pnpm build (5 software pkgs + workflow)
    BT->>Docker: Build container image
    Docker-->>BT: Image ready
    BT->>Reg: Push image to trusted registry
    Reg-->>BT: Image published
    BT-->>CI: "Release descriptor with remoteArtifactLocation = containers.pl-open.science/..."
    CI->>Backend: Deploy block with new descriptor
    Backend->>Reg: Pull image (trusted registry)
    Reg-->>Backend: Image pulled successfully
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump block-tools to 2.12.7 to pub..."](https://github.com/platforma-open/antibody-tcr-lead-selection/commit/c8adf0f45b5382ba4d5bb8c8248741161ebcf341) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45178268)</sub>

<!-- /greptile_comment -->