### PR TITLE
MILAB-6642: drop empty clonotypeKey rows from selection-stage output

### DIFF
--- a/.changeset/fix-selection-stage-empty-key.md
+++ b/.changeset/fix-selection-stage-empty-key.md
@@ -1,0 +1,7 @@
+---
+"@platforma-open/milaboratories.top-antibodies.sample-clonotypes": patch
+"@platforma-open/milaboratories.top-antibodies.workflow": patch
+"@platforma-open/milaboratories.top-antibodies": patch
+---
+
+Fix selectionStage PColumn build failure caused by empty clonotypeKey rows. The upstream Full join can emit secondary-axis (cluster/linker) rows not tied to any clonotype; their empty clonotypeKey collided on the single-axis selectionStage frame. filter.py now drops null/empty clonotypeKey rows from the selection-stage output.

--- a/software/sample-clonotypes/src/filter.py
+++ b/software/sample-clonotypes/src/filter.py
@@ -73,24 +73,26 @@ def apply_filter(df, column_name, filter_type, reference_value):
                             string_in, string_notIn, isNA, isNotNA")
 
 
-def drop_empty_keys(selection_df):
-    """Remove rows with null or empty clonotypeKey from the selection-stage table.
+def drop_empty_keys(df):
+    """Remove rows with null or empty clonotypeKey.
 
     The clone table is built with a Full join upstream, which can introduce rows
     from secondary-axis columns (cluster/linker) that are not tied to any
     clonotype. Their clonotypeKey is null (empty string after the parquet
-    round-trip), and multiple such rows collide on the selectionStage PColumn
-    axis, which requires unique keys.
+    round-trip). Such rows are not real clonotypes; if kept they collide on any
+    PColumn built with clonotypeKey as a unique axis (e.g. selectionStage).
+    Dropping them at load keeps both the filtered output and the selection-stage
+    output clean.
     """
-    before = selection_df.height
-    selection_df = selection_df.filter(
+    before = df.height
+    df = df.filter(
         pl.col("clonotypeKey").is_not_null()
         & (pl.col("clonotypeKey").cast(pl.Utf8) != "")
     )
-    dropped = before - selection_df.height
+    dropped = before - df.height
     if dropped > 0:
         print(f"drop_empty_keys: removed {dropped} rows with empty/null clonotypeKey")
-    return selection_df
+    return df
 
 
 def apply_filters(df, filter_map):
@@ -114,10 +116,6 @@ def apply_filters(df, filter_map):
         selection_df = df.select("clonotypeKey").with_columns(
             pl.lit(1).cast(pl.Int64).alias("selectionStage")
         )
-        # Drop rows with empty/null clonotypeKey: the Full join upstream can emit
-        # secondary-axis (cluster/linker) rows not tied to any clonotype; these
-        # collide on the selectionStage PColumn axis (all key == "").
-        selection_df = drop_empty_keys(selection_df)
         return df.with_columns(pl.lit(1).alias("top")), selection_df
 
     filtered_df = df.clone()
@@ -173,10 +171,6 @@ def apply_filters(df, filter_map):
     selection_parts.append(survivors)
 
     selection_df = pl.concat(selection_parts)
-    # Drop rows with empty/null clonotypeKey: the Full join upstream can emit
-    # secondary-axis (cluster/linker) rows not tied to any clonotype; these
-    # collide on the selectionStage PColumn axis (all key == "").
-    selection_df = drop_empty_keys(selection_df)
     print(f"Selection stage tracking: {selection_df.height} total clones across {n_filters} filter stages")
 
     return filtered_df, selection_df
@@ -242,6 +236,11 @@ def main():
         print(f"Empty output file created: {args.out}")
         print(f"Total time: {total_time:.3f}s")
         return
+
+    # Drop empty/null clonotypeKey rows once, at the source, so both the filtered
+    # output (args.out) and the selection-stage output are free of Full-join
+    # secondary-axis rows that would collide on a unique clonotypeKey axis.
+    df = drop_empty_keys(df)
 
     # Parse filter map from JSON string
     try:

--- a/software/sample-clonotypes/src/filter.py
+++ b/software/sample-clonotypes/src/filter.py
@@ -73,6 +73,26 @@ def apply_filter(df, column_name, filter_type, reference_value):
                             string_in, string_notIn, isNA, isNotNA")
 
 
+def drop_empty_keys(selection_df):
+    """Remove rows with null or empty clonotypeKey from the selection-stage table.
+
+    The clone table is built with a Full join upstream, which can introduce rows
+    from secondary-axis columns (cluster/linker) that are not tied to any
+    clonotype. Their clonotypeKey is null (empty string after the parquet
+    round-trip), and multiple such rows collide on the selectionStage PColumn
+    axis, which requires unique keys.
+    """
+    before = selection_df.height
+    selection_df = selection_df.filter(
+        pl.col("clonotypeKey").is_not_null()
+        & (pl.col("clonotypeKey").cast(pl.Utf8) != "")
+    )
+    dropped = before - selection_df.height
+    if dropped > 0:
+        print(f"drop_empty_keys: removed {dropped} rows with empty/null clonotypeKey")
+    return selection_df
+
+
 def apply_filters(df, filter_map):
     """
     Apply all filters specified in the filter_map to the DataFrame.
@@ -94,6 +114,10 @@ def apply_filters(df, filter_map):
         selection_df = df.select("clonotypeKey").with_columns(
             pl.lit(1).cast(pl.Int64).alias("selectionStage")
         )
+        # Drop rows with empty/null clonotypeKey: the Full join upstream can emit
+        # secondary-axis (cluster/linker) rows not tied to any clonotype; these
+        # collide on the selectionStage PColumn axis (all key == "").
+        selection_df = drop_empty_keys(selection_df)
         return df.with_columns(pl.lit(1).alias("top")), selection_df
 
     filtered_df = df.clone()
@@ -149,6 +173,10 @@ def apply_filters(df, filter_map):
     selection_parts.append(survivors)
 
     selection_df = pl.concat(selection_parts)
+    # Drop rows with empty/null clonotypeKey: the Full join upstream can emit
+    # secondary-axis (cluster/linker) rows not tied to any clonotype; these
+    # collide on the selectionStage PColumn axis (all key == "").
+    selection_df = drop_empty_keys(selection_df)
     print(f"Selection stage tracking: {selection_df.height} total clones across {n_filters} filter stages")
 
     return filtered_df, selection_df


### PR DESCRIPTION
The clone table is built with a Full join, which can emit secondary-axis (cluster/linker) rows not tied to any clonotype. Their clonotypeKey is empty, and multiple such rows collided on the single-axis selectionStage PColumn, failing ptabler write_frame with "Multiple rows with the same axis key: []".

filter.py now drops null/empty clonotypeKey rows in both selection-stage paths (empty filter map and the main path).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a `ptabler write_frame` crash caused by empty `clonotypeKey` values colliding on the single-axis `selectionStage` PColumn. The root cause is that the upstream Full join can emit secondary-axis (cluster/linker) rows with no corresponding clonotype, leaving their `clonotypeKey` null (serialized as `""` after a parquet round-trip).

- Introduces `drop_empty_keys(selection_df)`, which filters rows where `clonotypeKey` is null or empty string, and wires it into both the empty-filter-map fast path and the main multi-stage filtering path inside `apply_filters`.
- Adds a diagnostic `print` when rows are dropped, making the behavior observable in logs without being noisy on clean inputs.
- Changeset bumps `sample-clonotypes`, `workflow`, and the top-level package at patch level.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a targeted, minimal fix that addresses a confirmed crash; the new function is simple and applied consistently in both code paths that produce the selection-stage output.

The `drop_empty_keys` logic is correct and the fix resolves the described failure. The one open question is whether `filtered_df` (the main output parquet) also needs cleaning for empty `clonotypeKey` rows — it currently does not get the same treatment, and if any future downstream consumer imposes a unique-key constraint on that file, the same class of issue could resurface.

software/sample-clonotypes/src/filter.py — specifically the return value of `filtered_df` in both branches of `apply_filters`, which retains empty `clonotypeKey` rows.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| software/sample-clonotypes/src/filter.py | Adds `drop_empty_keys` helper and calls it on `selection_df` in both the empty-filter-map fast path and the main multi-stage filtering path, fixing the PColumn axis-key collision bug. The fix is correctly scoped; `filtered_df` (main output) still retains empty-key rows. |
| .changeset/fix-selection-stage-empty-key.md | Correct patch-level changeset entry describing the bug fix; bumps all three affected packages. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[filter.py: apply_filters] --> B{filter_map empty?}
    B -- Yes --> C["selection_df = df.select('clonotypeKey')\n+ selectionStage=1"]
    B -- No --> D[Multi-stage filter loop\ncollect selection_parts]
    D --> E["survivors = filtered_df.select('clonotypeKey')\n+ selectionStage=N+1"]
    E --> F["selection_df = pl.concat(selection_parts)"]
    C --> G["drop_empty_keys(selection_df)\n NEW: removes null/empty clonotypeKey rows"]
    F --> G
    G --> H["write selection_df to args.emit_selection\n(unique clonotypeKey axis)"]
    H --> I["main.py reads selection_in\nbumps sampled clones to final stage"]
    I --> J["write selection_out to selectionStage PColumn\n(no key collision)"]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asoftware%2Fsample-clonotypes%2Fsrc%2Ffilter.py%3A121%0A**Empty-key%20rows%20persist%20in%20%60filtered_df%60%20output**%0A%0A%60drop_empty_keys%60%20is%20correctly%20applied%20to%20%60selection_df%60%20in%20both%20paths%2C%20but%20%60filtered_df%60%20%28written%20to%20%60args.out%60%29%20is%20returned%20unchanged%20in%20the%20empty-filter-map%20fast%20path%20%28%60df.with_columns%28pl.lit%281%29.alias%28%22top%22%29%29%60%29.%20Empty-clonotypeKey%20rows%20from%20the%20Full%20join%20remain%20in%20that%20parquet.%20If%20any%20downstream%20consumer%20of%20%60args.out%60%20builds%20a%20PColumn%20that%20requires%20unique%20%60clonotypeKey%60%20axis%20values%20%28similar%20to%20%60selectionStage%60%29%2C%20it%20would%20encounter%20the%20same%20collision.%20The%20same%20applies%20to%20the%20main%20path's%20%60filtered_df%60%20return%20value.%0A%0A&repo=platforma-open%2Fantibody-tcr-lead-selection&pr=168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
software/sample-clonotypes/src/filter.py:121
**Empty-key rows persist in `filtered_df` output**

`drop_empty_keys` is correctly applied to `selection_df` in both paths, but `filtered_df` (written to `args.out`) is returned unchanged in the empty-filter-map fast path (`df.with_columns(pl.lit(1).alias("top"))`). Empty-clonotypeKey rows from the Full join remain in that parquet. If any downstream consumer of `args.out` builds a PColumn that requires unique `clonotypeKey` axis values (similar to `selectionStage`), it would encounter the same collision. The same applies to the main path's `filtered_df` return value.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6642: drop empty clonotypeKey rows..."](https://github.com/platforma-open/antibody-tcr-lead-selection/commit/7af3f2dd89f948063b291cd6ee5494781fa0527d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46260380)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->