### PR TITLE
Julenmendieta/MILAB-6646_switchToRepertoireScore

### DIFF
--- a/.changeset/sixty-groups-change.md
+++ b/.changeset/sixty-groups-change.md
@@ -1,9 +1,9 @@
 ---
-"@platforma-open/milaboratories.top-antibodies.sample-clonotypes": minor
-"@platforma-open/milaboratories.top-antibodies.workflow": minor
-"@platforma-open/milaboratories.top-antibodies.model": minor
-"@platforma-open/milaboratories.top-antibodies.ui": minor
-"@platforma-open/milaboratories.top-antibodies": minor
+"@platforma-open/milaboratories.top-antibodies.sample-clonotypes": major
+"@platforma-open/milaboratories.top-antibodies.workflow": major
+"@platforma-open/milaboratories.top-antibodies.model": major
+"@platforma-open/milaboratories.top-antibodies.ui": major
+"@platforma-open/milaboratories.top-antibodies": major
 ---
 
 Remove old in vivo score and enable default ranking by repertoire score in "in Vivo" preset

--- a/.changeset/sixty-groups-change.md
+++ b/.changeset/sixty-groups-change.md
@@ -1,0 +1,9 @@
+---
+"@platforma-open/milaboratories.top-antibodies.sample-clonotypes": minor
+"@platforma-open/milaboratories.top-antibodies.workflow": minor
+"@platforma-open/milaboratories.top-antibodies.model": minor
+"@platforma-open/milaboratories.top-antibodies.ui": minor
+"@platforma-open/milaboratories.top-antibodies": minor
+---
+
+Remove old in vivo score and enable default ranking by repertoire score in "in Vivo" preset

--- a/docs/description.md
+++ b/docs/description.md
@@ -6,7 +6,7 @@ Ranks and selects top lead candidates — antibodies, TCRs, or peptides — usin
 
 The block offers built-in presets for common discovery workflows:
 
-* **In Vivo (immunization/infection):** Ranks antibody/TCR candidates by In Vivo Score, a composite metric calculated from clonal expansion, CDR mutation frequency, and germinal center selection signals. Applies default filters on mutation-related metrics (e.g., fraction of CDR mutations, total number of mutations) to focus on immune-refined candidates.
+* **In Vivo (immunization/infection):** Ranks antibody/TCR candidates by the Repertoire Score exported by the upstream Repertoire Score block — a composite metric combining clonal expansion, CDR mutation frequency, and germinal center selection signals. Applies default filters on mutation-related metrics (e.g., fraction of CDR mutations, total number of mutations) to focus on immune-refined candidates.
 * **In Vitro (display/panning):** Ranks antibody/TCR candidates by enrichment scores across selection rounds to identify clones selected for target binding.
 * **Peptide:** Ranks peptide candidates by all available numeric score columns (typically enrichment, sequence properties, and liabilities). Suited for peptide selection campaigns where SHM-based metrics are not applicable.
 

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -29,7 +29,6 @@ import {
   commonExcludeSelectors,
   getInputAnchorRef,
   getInputFilterRef,
-  IN_VIVO_SCORE_COLUMN_ID,
   isClusterIdAxisName,
   isProducedByLeadSelection,
   isSelectableMatch,
@@ -203,18 +202,6 @@ export const platforma = BlockModelV3.create(blockDataModel)
       value: matchToColumnId(value, inputAnchor!),
     }));
 
-    // Add synthetic In Vivo Score option when mutation columns are present
-    if (result.meta.hasInVivoScore) {
-      options.unshift({
-        label: "In Vivo Score",
-        value: {
-          anchorRef: inputAnchor!,
-          anchorName: "main",
-          column: IN_VIVO_SCORE_COLUMN_ID,
-        },
-      });
-    }
-
     return {
       options,
       defaults: result.meta.defaultRankingOrder,
@@ -232,7 +219,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
 
       return {
         detectedPreset: result.meta.detectedPreset,
-        hasInVivoScore: result.meta.hasInVivoScore,
+        hasRepertoireScore: result.meta.hasRepertoireScore,
         hasEnrichmentScores: result.meta.hasEnrichmentScores,
       };
     },
@@ -473,7 +460,6 @@ export const platforma = BlockModelV3.create(blockDataModel)
           {
             match: (spec) =>
               spec.name === "pl7.app/ranking-order" ||
-              spec.name === "pl7.app/vdj/inVivoScore" ||
               isFilterOrRank(spec) ||
               (spec.name === Annotation.Label &&
                 spec.axesSpec.length === 1 &&

--- a/model/src/types.ts
+++ b/model/src/types.ts
@@ -167,8 +167,8 @@ export type ColumnsMeta = {
   scores: ColumnMatch[];
   defaultFilters: PlTableFiltersDefault[];
   defaultRankingOrder: RankingOrder[];
-  /** True when SHM mutation columns are present and In Vivo Score should replace them in ranking */
-  hasInVivoScore: boolean;
+  /** True when the Repertoire Score column is present upstream; it becomes the primary In Vivo ranking */
+  hasRepertoireScore: boolean;
   /** True when enrichment score columns are present */
   hasEnrichmentScores: boolean;
   /** Auto-detected preset based on available columns */

--- a/model/src/util.ts
+++ b/model/src/util.ts
@@ -101,8 +101,6 @@ export const IN_VIVO_FILTER_SPEC_NAMES = new Set([
   "pl7.app/vdj/isProductive",
   "pl7.app/developabilityRisk",
   "pl7.app/vdj/developabilityRisk",
-  // Convergent hit (clonotype-convergence) — default "keep only Hit" filter.
-  "pl7.app/vdj/convergence/fastStar",
 ]);
 
 // In Vivo preset allowlist for ranking. The Repertoire Score (pulled to the front
@@ -112,8 +110,6 @@ export const IN_VIVO_RANKING_SPEC_NAMES = new Set([
   "pl7.app/vdj/repertoireScore",
   "pl7.app/developabilityScore",
   "pl7.app/vdj/developabilityScore",
-  // Convergent neighbour frequency (clonotype-convergence) — ranked descending.
-  "pl7.app/vdj/convergence/nbFreq",
 ]);
 
 // In Vitro preset allowlists. Same intersection-with-discovery approach as

--- a/model/src/util.ts
+++ b/model/src/util.ts
@@ -9,7 +9,6 @@ import {
   type PColumnSpec,
   type PlRef,
   type RenderCtx,
-  type SUniversalPColumnId,
 } from "@platforma-sdk/model";
 import type {
   BlockArgs,
@@ -79,10 +78,11 @@ export function matchToColumnId(match: ColumnMatch, anchorRef: PlRef): ScopedCol
   return { anchorRef, anchorName: "main", column: match.column.id };
 }
 
-// Sentinel column ID for the computed In Vivo Score ranking
-export const IN_VIVO_SCORE_COLUMN_ID = "pl7.app/vdj/inVivoScore" as SUniversalPColumnId;
+// The Repertoire Score exported by the repertoire-score block. When present
+// upstream it is used as the primary In Vivo ranking.
+export const REPERTOIRE_SCORE_COLUMN_NAME = "pl7.app/vdj/repertoireScore";
 
-// SHM mutation columns that are replaced by In Vivo Score in ranking.
+// SHM mutation columns that are replaced by the Repertoire Score in ranking.
 export const IN_VIVO_MUTATION_COLUMNS = new Set([
   "pl7.app/vdj/sequence/fractionCDRMutations",
   "pl7.app/vdj/sequence/nMutations",
@@ -105,9 +105,11 @@ export const IN_VIVO_FILTER_SPEC_NAMES = new Set([
   "pl7.app/vdj/convergence/fastStar",
 ]);
 
-// In Vivo preset allowlist for ranking. The In Vivo Score sentinel is added
-// separately when mutation columns are present.
+// In Vivo preset allowlist for ranking. The Repertoire Score (pulled to the front
+// in computePresets when present) is the primary ranking; the entries below are
+// kept as secondary rankings when their columns are present upstream.
 export const IN_VIVO_RANKING_SPEC_NAMES = new Set([
+  "pl7.app/vdj/repertoireScore",
   "pl7.app/developabilityScore",
   "pl7.app/vdj/developabilityScore",
   // Convergent neighbour frequency (clonotype-convergence) — ranked descending.
@@ -335,9 +337,10 @@ function computePresets(
 ): Omit<ColumnsMeta, "allMatches" | "scores" | "defaultFilters"> {
   const isPeptide = anchorSpec.axesSpec[1]?.name === "pl7.app/variantKey";
 
-  const hasInVivoScore = [...IN_VIVO_MUTATION_COLUMNS].every((name) =>
-    scores.some((s) => s.column.spec.name === name),
-  );
+  // The Repertoire Score (repertoire-score block), when present upstream, is the
+  // In Vivo preset's primary ranking.
+  const repertoireScore = scores.find((s) => s.column.spec.name === REPERTOIRE_SCORE_COLUMN_NAME);
+  const hasRepertoireScore = repertoireScore !== undefined;
 
   const isEnrichmentColumn = (name: string) =>
     name.startsWith("pl7.app/enrichment") || name.startsWith("pl7.app/vdj/enrichment");
@@ -347,16 +350,19 @@ function computePresets(
   // score columns are upstream.
   const detectedPreset: WorkflowPreset | undefined = isPeptide
     ? "peptide"
-    : hasInVivoScore
+    : hasRepertoireScore
       ? "in-vivo"
       : hasEnrichmentScores
         ? "in-vitro"
         : undefined;
 
-  // Default ranking: all non-String scores, excluding mutation columns when In Vivo Score replaces them
+  // Default ranking: all non-String scores. When the Repertoire Score is present
+  // it is pulled to the front (below) as the primary ranking, and the raw SHM
+  // mutation columns it subsumes are dropped.
   const defaultRankingOrder: RankingOrder[] = scores
     .filter((s) => s.column.spec.valueType !== "String")
-    .filter((s) => !hasInVivoScore || !IN_VIVO_MUTATION_COLUMNS.has(s.column.spec.name))
+    .filter((s) => !hasRepertoireScore || s.column.spec.name !== REPERTOIRE_SCORE_COLUMN_NAME)
+    .filter((s) => !hasRepertoireScore || !IN_VIVO_MUTATION_COLUMNS.has(s.column.spec.name))
     .map((s) => ({
       id: `default-rank-${s.column.id}`,
       value: matchToColumnId(s, anchorRef),
@@ -367,10 +373,13 @@ function computePresets(
       isExpanded: false,
     }));
 
-  if (hasInVivoScore) {
+  if (repertoireScore) {
     defaultRankingOrder.unshift({
-      value: { anchorRef, anchorName: "main", column: IN_VIVO_SCORE_COLUMN_ID },
-      rankingOrder: "decreasing",
+      value: matchToColumnId(repertoireScore, anchorRef),
+      rankingOrder:
+        (repertoireScore.column.spec.annotations?.["pl7.app/score/rankingOrder"] as
+          | "increasing"
+          | "decreasing") ?? "decreasing",
     });
   }
 
@@ -427,7 +436,6 @@ function computePresets(
 
   const inVivoRankingOrder: RankingOrder[] = defaultRankingOrder.filter((r) => {
     const col = r.value?.column;
-    if (col === IN_VIVO_SCORE_COLUMN_ID) return true;
     if (col === undefined) return false;
     const specName = specNameByColumnId.get(col);
     return specName !== undefined && IN_VIVO_RANKING_SPEC_NAMES.has(specName);
@@ -454,7 +462,7 @@ function computePresets(
 
   return {
     defaultRankingOrder,
-    hasInVivoScore,
+    hasRepertoireScore,
     hasEnrichmentScores,
     detectedPreset,
     inVivoDefaults,

--- a/software/sample-clonotypes/src/filter.py
+++ b/software/sample-clonotypes/src/filter.py
@@ -176,30 +176,6 @@ def apply_filters(df, filter_map):
     return filtered_df, selection_df
 
 
-def aggregate_across_samples(df):
-    """Collapse sample dimension by summing abundance across samples.
-
-    Only applies when the sampleId column is present (In Vivo Score case).
-    All columns except sampleId and inVivo_primaryAbundance have identical values
-    per clonotype, so grouping by them naturally deduplicates the rows.
-    """
-    if "sampleId" not in df.columns:
-        return df
-
-    # Abundance may be loaded as String with "" for missing values
-    if df["inVivo_primaryAbundance"].dtype == pl.Utf8:
-        df = df.with_columns(
-            pl.col("inVivo_primaryAbundance").replace("", None).cast(pl.Int64)
-        )
-
-    group_cols = [col for col in df.columns 
-                     if col not in ("sampleId", "inVivo_primaryAbundance")]
-    rows_before = df.height
-    df = df.group_by(group_cols).agg(pl.col("inVivo_primaryAbundance").sum()).sort("clonotypeKey")
-    print(f"Aggregated across samples: {rows_before} -> {df.height} rows (summed inVivo_primaryAbundance)")
-    return df
-
-
 def main():
     start_time = time.time()
     print(f"filter.py:main() START at {time.strftime('%H:%M:%S')}")
@@ -291,9 +267,6 @@ def main():
             & (pl.col("primary_filter").cast(pl.Utf8) != "")
         )
         print(f"Primary filter pre-drop: {before_primary} -> {df.height} rows")
-
-    # Collapse sample dimension if present (In Vivo Score case)
-    df = aggregate_across_samples(df)
 
     # Apply filters
     filtering_start = time.time()

--- a/software/sample-clonotypes/src/main.py
+++ b/software/sample-clonotypes/src/main.py
@@ -8,49 +8,6 @@ import time
 import json
 
 
-
-# In Vivo Score: source column headers and composite weights
-IN_VIVO_SCORE_SOURCES = {
-    "inVivo_primaryAbundance": 0.40,
-    "inVivo_fractionCDR": 0.35,
-    "inVivo_nMutations": 0.25,
-}
-
-
-def compute_in_vivo_score(df):
-    """Compute In Vivo Score: weighted percentile combination of primary abundance,
-    CDR mutation fraction, and total nucleotide mutations.
-
-    score = 0.40 * percentile(primaryAbundance)
-          + 0.35 * percentile(fractionCDRMutations)
-          + 0.25 * percentile(nMutations)
-
-    percentile(x) = (average_rank(x) - 1) / (N - 1), where N = non-NA count.
-    NA -> 0.0. When N = 1, percentile = 0.5.
-    """
-    missing = [col for col in IN_VIVO_SCORE_SOURCES if col not in df.columns]
-    if missing:
-        print(f"Warning: Missing In Vivo Score source columns: {missing}. Cannot compute score.")
-        return df
-
-    score_expr = pl.lit(0.0)
-    for col_name, weight in IN_VIVO_SCORE_SOURCES.items():
-        n = df[col_name].drop_nulls().len()
-        if n == 0:
-            pct = pl.lit(0.0)
-        elif n == 1:
-            pct = pl.when(pl.col(col_name).is_not_null()).then(0.5).otherwise(0.0)
-        else:
-            pct = (
-                (pl.col(col_name).rank(method="average") - 1) / (n - 1)
-            ).fill_null(0.0)
-        score_expr = score_expr + pct * weight
-
-    df = df.with_columns(score_expr.alias("inVivoScore"))
-    print(f"Computed In Vivo Score for {df.height} rows")
-    return df
-
-
 def parse_arguments():
     parser = argparse.ArgumentParser(description="Rank rows based on Col* columns and output top N rows. Supports Col0, Col1 (clonotype properties), Col_cluster.0 (cluster properties), and Col_linker.0.0, Col_linker.0.1 (linker properties).")
     parser.add_argument("--parquet", required=True, help="Path to input Parquet file")
@@ -244,18 +201,6 @@ def main():
           f"({len(clonotype_col_columns)} clonotype, {len(cluster_col_columns)} cluster, " +
           f"{len(linker_col_columns)} linker)")
 
-    # Compute In Vivo Score if requested in ranking map
-    if args.ranking_map:
-        try:
-            raw_map = json.loads(args.ranking_map)
-            if "inVivoScore" in raw_map:
-                df = compute_in_vivo_score(df)
-                if "inVivoScore" in df.columns:
-                    all_ranking_cols = ["inVivoScore"] + all_ranking_cols
-                    print(f"  Added In Vivo Score computed from source columns: {list(IN_VIVO_SCORE_SOURCES.keys())}")
-        except json.JSONDecodeError:
-            pass  # Will be handled by parse_ranking_map
-
     # Parse ranking map
     ranking_map = parse_ranking_map(args.ranking_map, all_ranking_cols)
     if ranking_map is None:
@@ -279,8 +224,6 @@ def main():
     output_columns['clonotypeKey'] = result['clonotypeKey']
     output_columns['top'] = [1] * result.height
     output_columns['ranked_order'] = result['ranked_order']
-    if 'inVivoScore' in result.columns:
-        output_columns['inVivoScore'] = result['inVivoScore']
 
     simplified_df = pl.DataFrame(output_columns)
 

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -269,9 +269,9 @@ watch(
         <template #tooltip>
           Pre-configured ranking for common discovery workflows.
           <br /><br />
-          <b>In Vivo (immunization/infection):</b> Ranks by In Vivo Score, calculated from clonal
-          expansion, CDR mutations and germinal center selection metrics. Identifies immune-refined
-          candidates. <br /><br />
+          <b>In Vivo (immunization/infection):</b> Ranks by the Repertoire Score (from the
+          Repertoire Score block), a composite of clonal expansion, CDR mutations and germinal
+          center selection signals. Identifies immune-refined candidates. <br /><br />
           <b>In Vitro (display/panning):</b> — Ranks by enrichment across selection rounds.
           Identifies clones selected for target binding. <br /><br />
           <b>Peptide:</b> Ranks by all available numeric score columns (e.g., enrichment, sequence

--- a/workflow/src/filter-and-sample.tpl.tengo
+++ b/workflow/src/filter-and-sample.tpl.tengo
@@ -44,16 +44,8 @@ self.body(func(inputs) {
     filteredClonotypes := filterResult.getFile("filteredClonotypes.parquet")
     selectionParquet := filterResult.getFile("selection.parquet")
 
-    // Check if In Vivo Score is in the ranking map
-    hasInVivoScore := false
-    for key, _ in rankingMap {
-        if key == "inVivoScore" {
-            hasInVivoScore = true
-        }
-    }
-
     // Store outputs
-    sampledColsParams := sampledColsConv.getColumns(datasetSpec, false, false) // No ranking column
+    sampledColsParams := sampledColsConv.getColumns(datasetSpec, false) // No ranking column
     filteredClonotypesPf := xsv.importFile(filteredClonotypes, "parquet", sampledColsParams,
                                         {cpu: 1, mem: "16GiB"})
 
@@ -96,7 +88,7 @@ self.body(func(inputs) {
 		selectionParquet = sampleClones.getFile("selection_out.parquet")
 
 		// Store outputs
-        sampledColsParams := sampledColsConv.getColumns(datasetSpec, true, hasInVivoScore) // Add ranking column
+        sampledColsParams := sampledColsConv.getColumns(datasetSpec, true) // Add ranking column
 		sampledColumnsPf := xsv.importFile(finalClonotypes, "parquet", sampledColsParams,
 											{cpu: 1, mem: "16GiB"})
 		outputs["sampledRows"] = pframes.exportFrame(sampledColumnsPf)

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -40,19 +40,6 @@ wf.prepare(func(args){
         for col in args.rankingOrder {
             // For cases where the user is selecting the table to filter
             if col.value != undefined {
-                // In Vivo Score is computed from source columns, not a real PColumn
-                if col.value.column == "pl7.app/vdj/inVivoScore" {
-                    // Primary abundance is the input anchor itself — already added above.
-                    // Fetch the remaining source columns by name.
-                    for key, name in utils.inVivoScoreSourceColumns {
-                        bundleBuilder.addMulti({
-                            axes: [{ anchor: "main", idx: 1 }],
-                            name: name
-                        }, "inVivo_" + key)
-                    }
-                    validRanks = true
-                    continue
-                }
                 bundleBuilder.addSingle(col.value.column)
                 validRanks = true
             }

--- a/workflow/src/sampled-cols-conv.lib.tengo
+++ b/workflow/src/sampled-cols-conv.lib.tengo
@@ -1,6 +1,6 @@
 ll := import("@platforma-sdk/workflow-tengo:ll")
 
-getColumns := func(datasetSpec, addRanking, addInVivoScore) {
+getColumns := func(datasetSpec, addRanking) {
   columns := [{
         column: "top",
         id: "link",
@@ -32,22 +32,6 @@ getColumns := func(datasetSpec, addRanking, addInVivoScore) {
         }
       }]
   }
-  if addInVivoScore {
-    columns = columns + [{
-        column: "inVivoScore",
-        spec: {
-          name: "pl7.app/vdj/inVivoScore",
-          valueType: "Float",
-          domain: {},
-          annotations: {
-            "pl7.app/label": "In Vivo Score",
-            "pl7.app/table/visibility": "optional",
-            "pl7.app/format": ".2f"
-          }
-        }
-      }]
-  }
-
   return {
     axes: [
       {

--- a/workflow/src/utils.lib.tengo
+++ b/workflow/src/utils.lib.tengo
@@ -7,13 +7,6 @@ pSpec := import("@platforma-sdk/workflow-tengo:pframes.spec")
 pUtil := import("@platforma-sdk/workflow-tengo:pframes.util")
 json := import("json")
 
-// PColumn names used as source columns for In Vivo Score computation.
-// Primary abundance is resolved separately via specific annotations.
-inVivoScoreSourceColumns := {
-    "fractionCDR": "pl7.app/vdj/sequence/fractionCDRMutations",
-    "nMutations": "pl7.app/vdj/sequence/nMutations"
-}
-
 // Cluster-id axis names — both unprefixed (post-peptide-adaptation) and
 // `pl7.app/vdj/`-prefixed (pre-peptide) so older clonotype-clustering
 // instances remain selectable as diversification linkers.
@@ -353,21 +346,6 @@ initializeCloneTable := func(pframes, columns, args, datasetSpec, inputFilterCol
     
     if len(args.rankingOrder) > 0 {
         for i, col in args.rankingOrder {
-            // In Vivo Score: add source columns to the clone table for later computation
-            if col.value != undefined && col.value.column == "pl7.app/vdj/inVivoScore" {
-                // Primary abundance is the input anchor itself; it introduces the sampleId axis
-                cloneTable.setAxisHeader(datasetSpec.axesSpec[0], "sampleId")
-                cloneTable.add(columns.getColumn(args.inputAnchor), {header: "inVivo_primaryAbundance"})
-                addedCols = true
-                for key, _ in inVivoScoreSourceColumns {
-                    for srcCol in columns.getColumns("inVivo_" + key) {
-                        cloneTable.add(srcCol, {header: "inVivo_" + key})
-                        addedCols = true
-                    }
-                }
-                rankingMap["inVivoScore"] = col.rankingOrder
-                continue
-            }
             // we check for value presence and for actual pcolumn (cases where upstream block is deleted)
             if col.value != undefined && columns.getColumn(col.value.column).spec != undefined {
                 // Process the ranking column to determine header and cluster axis
@@ -428,7 +406,7 @@ initializeCloneTable := func(pframes, columns, args, datasetSpec, inputFilterCol
         }
     }
     for i, col in args.rankingOrder {
-        if col.value != undefined && col.value.column != "pl7.app/vdj/inVivoScore" {
+        if col.value != undefined {
             colSpec := columns.getColumn(col.value.column)
             if !is_undefined(colSpec) && !is_undefined(colSpec.spec) {
                 for ax in colSpec.spec.axesSpec {
@@ -863,6 +841,5 @@ export {
     initializeAssemSeqTable: initializeAssemSeqTable,
     formatFilterDescription: formatFilterDescription,
     buildFilterTraceLabel: buildFilterTraceLabel,
-    buildFilterStageNames: buildFilterStageNames,
-    inVivoScoreSourceColumns: inVivoScoreSourceColumns
+    buildFilterStageNames: buildFilterStageNames
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the locally computed In Vivo Score with the upstream Repertoire Score throughout preset detection, ranking, workflow execution, and documentation.
- **Repertoire Score** — An upstream score combining clonal expansion, CDR mutation frequency, and germinal-center selection signals. It now determines In Vivo preset detection and becomes the primary default ranking column.
- **In Vivo Score** — The former locally computed weighted-percentile score. Its model sentinel, source-column handling, Python computation, cross-sample aggregation, output column, and workflow metadata are removed.
- **In Vivo preset** — The preset for immunization or infection workflows. It is now detected when Repertoire Score is available and ranks that score first while excluding the mutation metrics subsumed by it.
- **Ranking order** — The ordered score columns used to select leads. Repertoire Score is moved to the front and uses its ranking-order annotation, defaulting to decreasing.
- **Sampled columns** — The output schema for selected clonotypes. It no longer conditionally publishes a generated In Vivo Score column.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defect established.

The former synthetic-score branches are removed consistently across the model, workflow, Python processing, output schema, UI, and documentation, while the upstream score follows the existing ranking-column path.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model/src/util.ts | Replaces synthetic In Vivo Score detection and ranking with discovery and prioritization of the upstream Repertoire Score column. |
| model/src/index.ts | Removes the synthetic score option and exposes Repertoire Score availability in preset metadata. |
| workflow/src/main.tpl.tengo | Removes special source-column bundling for the locally computed In Vivo Score. |
| workflow/src/utils.lib.tengo | Routes Repertoire Score through the standard ranking-column path and removes synthetic-score table construction. |
| software/sample-clonotypes/src/main.py | Removes local In Vivo Score calculation and its generated output column. |
| software/sample-clonotypes/src/filter.py | Removes the sample aggregation that existed specifically for the retired synthetic-score path. |
| workflow/src/sampled-cols-conv.lib.tengo | Simplifies sampled-output schema generation by removing the optional synthetic score column. |
| ui/src/pages/MainPage.vue | Updates In Vivo preset guidance to describe the upstream Repertoire Score. |
| docs/description.md | Documents Repertoire Score as the In Vivo preset's primary ranking metric. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Upstream score columns] --> B{Repertoire Score present?}
  B -- Yes --> C[Detect In Vivo preset]
  C --> D[Place Repertoire Score first]
  D --> E[Remove subsumed mutation rankings]
  E --> F[Build clone table with ordinary ranking column]
  F --> G[Filter and sample clonotypes]
  B -- No --> H[Use enrichment or generic preset detection]
  H --> F
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Changeset"](https://github.com/platforma-open/antibody-tcr-lead-selection/commit/583b0ec74c95d198be0bd9b4cfc8060349b39bed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46618058)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->