### PR TITLE
Fix 3d cluster diversification

### DIFF
--- a/.changeset/fix-diversification-by-sparse-cluster-column.md
+++ b/.changeset/fix-diversification-by-sparse-cluster-column.md
@@ -1,4 +1,5 @@
 ---
+'@platforma-open/milaboratories.top-antibodies': patch
 '@platforma-open/milaboratories.top-antibodies.workflow': patch
 '@platforma-open/milaboratories.top-antibodies.sample-clonotypes': patch
 ---

--- a/.changeset/fix-diversification-by-sparse-cluster-column.md
+++ b/.changeset/fix-diversification-by-sparse-cluster-column.md
@@ -1,0 +1,24 @@
+---
+'@platforma-open/milaboratories.top-antibodies.workflow': patch
+'@platforma-open/milaboratories.top-antibodies.sample-clonotypes': patch
+---
+
+Fix diversification by cluster columns from 3d-structure-clustering
+
+Diversification silently did nothing when the selected cluster column came from a
+clustering block whose `clusterSize` column was not fetched into the bundle (e.g.
+3d-structure-clustering, which emits `pl7.app/structure/clustering/clusterSize`).
+`resolveClusterColumnHeader` returned a `clusterAxis_<idx>_0` header that only the
+cluster-size loop ever creates, so the sampler logged "Diversification column not
+found" and skipped diversification entirely. It now returns the linker's own
+`cluster_<idx>` header, which exists whenever the linker is in the clone table.
+
+Clonotypes with no cluster assigned are now excluded from selection again. They
+arrive in the clone table as empty strings — `parquetFileBuilder` writes missing
+values as `""` — so the existing `drop_nulls` guard never saw them and they leaked
+into the leads table after the clone table moved from an Inner to a Full join.
+
+Also widened the `clusterSizes` bundle query to match
+`pl7.app/structure/clustering/clusterSize`, making 3D cluster sizes available, and
+stopped the cluster-size loop from renaming an axis the linker loop already
+headered.

--- a/software/sample-clonotypes/src/main.py
+++ b/software/sample-clonotypes/src/main.py
@@ -15,7 +15,7 @@ def parse_arguments():
     parser.add_argument("--out", required=True, help="Path to output Parquet file")
     parser.add_argument("--ranking-map", type=str, help='JSON string specifying ranking direction for each column, e.g., {"Col0":"decreasing","Col1":"increasing","Col_linker.0.0":"decreasing"}')
     parser.add_argument("--diversification-column", type=str,
-                        help="Column header name to use for diversified ranking (e.g., 'clusterAxis_0_0')")
+                        help="Column header name to use for diversified ranking (e.g., 'cluster_0')")
     parser.add_argument("--selection-in", type=str, required=False,
                         help="Path to selection stage parquet from filter.py (clonotypeKey + selectionStage)")
     parser.add_argument("--selection-out", type=str, required=False,
@@ -116,6 +116,19 @@ def diversified_rank_and_select(df, n, ranking_map, all_ranking_cols, diversific
         df = df.drop_nulls(subset=null_check_cols)
         print(f"Dropped null ranking/diversification rows: {before_null_drop} -> {df.height} "
               f"(checked: {null_check_cols})")
+
+    # A clonotype with no cluster assigned cannot be diversified against, so it is
+    # not eligible for selection. It arrives here as an EMPTY STRING, not a null:
+    # pframes.parquetFileBuilder defaults naStr/nullStr to "" when writing the
+    # clone table, so the Full join's unmatched keys become "" and drop_nulls above
+    # never sees them. Scoped to the diversification column only — ranking columns
+    # are cast to numeric above, where a missing value is already a real null.
+    if diversification_column and diversification_column in df.columns:
+        if df[diversification_column].dtype == pl.Utf8:
+            before_empty_drop = df.height
+            df = df.filter(pl.col(diversification_column) != "")
+            print(f"Dropped rows with unassigned '{diversification_column}': "
+                  f"{before_empty_drop} -> {df.height}")
 
     # Build sort criteria from ranking_map
     if all_ranking_cols:

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -71,10 +71,11 @@ wf.prepare(func(args){
     }
 
     // Add cluster size columns from clustering blocks. The namePattern matches
-    // both the post-peptide-adaptation name and the pre-peptide `pl7.app/vdj/`
-    // variant so older clonotype-clustering instances remain usable.
+    // the post-peptide-adaptation name, the pre-peptide `pl7.app/vdj/` variant
+    // (so older clonotype-clustering instances remain usable), and the
+    // `pl7.app/structure/` variant emitted by 3d-structure-clustering.
     bundleBuilder.addMulti({
-        namePattern: "^pl7\\.app/(vdj/)?clustering/clusterSize$",
+        namePattern: "^pl7\\.app/(vdj/|structure/)?clustering/clusterSize$",
         partialAxesMatch: true
     }, "clusterSizes")
 

--- a/workflow/src/utils.lib.tengo
+++ b/workflow/src/utils.lib.tengo
@@ -179,7 +179,18 @@ buildSortedLinkers := func(columns, datasetSpec) {
 
 /**
  * Resolves cluster column reference to header name by matching against sortedLinkers.
- * 
+ *
+ * Returns the linker's own cluster axis header ("cluster_<linkerIdx>", set in
+ * initializeCloneTable's linker loop). Do NOT return the "clusterAxis_<idx>_<n>"
+ * form: that header is only created by the cluster-size loop, and only for
+ * linkers whose clustering block exports a clusterSize column matching the
+ * bundle's namePattern. For a clustering block outside that pattern (e.g.
+ * 3d-structure-clustering, which exports pl7.app/structure/clustering/clusterSize)
+ * the header never exists, the sampler logs "Diversification column ... not found"
+ * and silently skips diversification. "cluster_<linkerIdx>" always exists whenever
+ * the linker is in the table, and the diversification linker is always added
+ * (its axis is forced into usedNonMainAxes below).
+ *
  * @param args - Arguments containing diversificationColumn
  * @param columns - PBundle containing all columns
  * @param sortedLinkers - List of linker columns in proper order
@@ -216,7 +227,7 @@ resolveClusterColumnHeader := func(args, columns, sortedLinkers) {
             if isClusterIdAxis(axis.name) {
                 // Use clusterAxisDomainsMatch for proper domain comparison
                 if clusterAxisDomainsMatch(selectedClusterIdAxis, axis) {
-                    return "clusterAxis_" + string(linkerIdx) + "_0"
+                    return "cluster_" + string(linkerIdx)
                 }
             }
         }
@@ -431,6 +442,11 @@ initializeCloneTable := func(pframes, columns, args, datasetSpec, inputFilterCol
 
     // Get linker columns — only add to clone table if their non-main axis is used
     linkerClusterIdAxesWithIdx := []
+    // Axes already headered "cluster_<linkerIdx>" by the linker loop. setAxisHeader
+    // is last-write-wins, so the cluster-size loop below must not rename these —
+    // "cluster_<linkerIdx>" is the name resolveClusterColumnHeader hands to the
+    // sampler as --diversification-column.
+    linkerHeaderedAxes := {}
 
     for linkerIdx, col in sortedLinkers {
         // Determine the linker's non-clonotypeKey axis
@@ -451,12 +467,14 @@ initializeCloneTable := func(pframes, columns, args, datasetSpec, inputFilterCol
             // clonotypeKey is in second axis
             cloneTable.add(col, {header: "linker." + string(linkerIdx)})
             cloneTable.setAxisHeader(col.spec.axesSpec[0], "cluster_" + string(linkerIdx))
+            linkerHeaderedAxes[col.spec.axesSpec[0].name] = true
             clusterIdAxis = col.spec.axesSpec[0]
             addedCols = true
         } else if datasetSpec.axesSpec[1].name == col.spec.axesSpec[0].name {
             // clonotypeKey is in first axis
             cloneTable.add(col, {header: "linker." + string(linkerIdx)})
             cloneTable.setAxisHeader(col.spec.axesSpec[1], "cluster_" + string(linkerIdx))
+            linkerHeaderedAxes[col.spec.axesSpec[1].name] = true
             clusterIdAxis = col.spec.axesSpec[1]
             addedCols = true
         }
@@ -500,9 +518,12 @@ initializeCloneTable := func(pframes, columns, args, datasetSpec, inputFilterCol
             if matchingLinkerIdx >= 0 {
                 cloneTable.add(col, {header: "clusterSize." + string(matchingLinkerIdx)})
                 addedCols = true
-                // Add the cluster axis header using matching linker index
+                // Add the cluster axis header using matching linker index, but never
+                // rename an axis the linker loop already headered "cluster_<linkerIdx>"
+                // — that name is what the sampler receives as --diversification-column.
                 for axisIdx, axis in col.spec.axesSpec {
-                    if axis.name != datasetSpec.axesSpec[1].name {
+                    if axis.name != datasetSpec.axesSpec[1].name &&
+                       is_undefined(linkerHeaderedAxes[axis.name]) {
                         cloneTable.setAxisHeader(axis, "clusterAxis_" + string(matchingLinkerIdx) + "_" + string(axisIdx))
                     }
                 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR repairs 3D-cluster diversification by consistently exposing and selecting the linker’s cluster axis.
- Changes diversification headers from the cluster-size-dependent `clusterAxis_<idx>_<n>` form to the linker-owned `cluster_<idx>` form.
- Preserves linker axis headers when cluster-size columns are subsequently added to the clone table.
- Extends the cluster-size bundle query to include `pl7.app/structure/clustering/clusterSize`.
- Excludes clonotypes whose diversification cluster is represented by an empty string after the full join.
- Important touched terms:
  - **Diversification column** — The clone-table column used to distribute selected clonotypes across clusters. It now resolves to the linker-owned `cluster_<idx>` header.
  - **Linker column** — A mapping between clonotypes and cluster identifiers. Its cluster-axis header is now the authoritative diversification header.
  - **Cluster axis** — The table axis containing cluster identifiers. Headers established by linker processing are now protected from later renaming.
  - **Cluster-size column** — A clustering output containing the number of members in each cluster. Bundle discovery now includes the 3D-structure clustering namespace.
  - **Unassigned clonotype** — A clonotype without a value on the selected cluster axis. Empty-string representations are now excluded before diversified selection.
  - **Full join** — The clone-table join mode that retains rows missing values from sparse inputs. The sampler now handles its empty-string cluster representation.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code-triggered failures identified.

The workflow now passes a cluster header that is created whenever the selected linker is included, preserves that header during cluster-size processing, and excludes the documented empty-string representation of unassigned clusters before sampling.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| software/sample-clonotypes/src/main.py | Filters empty-string cluster assignments before applying diversified ranking. |
| workflow/src/main.tpl.tengo | Expands cluster-size discovery to include the 3D-structure clustering namespace. |
| workflow/src/utils.lib.tengo | Resolves diversification through linker-owned cluster headers and prevents cluster-size processing from renaming them. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Selected diversification column] --> B[Match cluster axis to sorted linker]
    B --> C[Resolve cluster_idx header]
    C --> D[Build full-join clone table]
    D --> E{Cluster ID assigned?}
    E -- Empty or null --> F[Exclude from sampling]
    E -- Present --> G[Rank within cluster]
    G --> H[Interleave local ranks]
    H --> I[Select top N clonotypes]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix diversification by 3d-structure clus..."](https://github.com/platforma-open/antibody-tcr-lead-selection/commit/0f8ed5ff21be616eb9504cb374d8b8b772da8594) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47545800)</sub>

<!-- /greptile_comment -->