### PR TITLE
Julenmendieta/milab 6685 implement score migration

### DIFF
--- a/.changeset/lucky-moons-listen.md
+++ b/.changeset/lucky-moons-listen.md
@@ -1,0 +1,7 @@
+---
+"@platforma-open/milaboratories.top-antibodies.model": patch
+"@platforma-open/milaboratories.top-antibodies.ui": patch
+"@platforma-open/milaboratories.top-antibodies": patch
+---
+
+Migrate projects that ranked by the removed built-in In Vivo Score: the stale ranking column is dropped and a one-time notice points to the Repertoire Score block, which now produces the score

--- a/model/src/dataModel.ts
+++ b/model/src/dataModel.ts
@@ -3,11 +3,13 @@ import {
   createPlDataTableStateV2,
   createPrimaryRef,
   DataModelBuilder,
+  type PObjectId,
 } from "@platforma-sdk/model";
 import type {
   BlockData,
   BlockData_Ver_2026_02_25,
   BlockData_Ver_2026_05_08,
+  BlockData_Ver_2026_05_21,
   LegacyBlockArgs,
   LegacyUiState,
 } from "./types";
@@ -18,6 +20,12 @@ const defaultSelectionPlotState = (): BlockData["selectionPlotState"] => ({
   template: "selection",
   currentTab: null,
 });
+
+/**
+ * Sentinel column id of the block's former built-in "In Vivo Score" ranking
+ * option.
+ */
+const REMOVED_IN_VIVO_SCORE_COLUMN_ID = "pl7.app/vdj/inVivoScore" as PObjectId;
 
 export const blockDataModel = new DataModelBuilder()
   .from<BlockData_Ver_2026_02_25>("Ver_2026_02_25")
@@ -57,7 +65,7 @@ export const blockDataModel = new DataModelBuilder()
     ...prev,
     selectionPlotState: defaultSelectionPlotState(),
   }))
-  .migrate<BlockData>("Ver_2026_05_21", (prev) => {
+  .migrate<BlockData_Ver_2026_05_21>("Ver_2026_05_21", (prev) => {
     const { inputAnchor, ...rest } = prev;
     return {
       ...rest,
@@ -66,6 +74,18 @@ export const blockDataModel = new DataModelBuilder()
           ? createDatasetSelection(createPrimaryRef(inputAnchor))
           : undefined,
     };
+  })
+  // The built-in "In Vivo Score" is gone — the Repertoire Score block produces
+  // the score now. Stored ranking entries still hold its sentinel id, which no
+  // longer matches any ranking option (red "Rank by" dropdown) and resolves to
+  // nothing when the workflow builds its column bundle. Drop those entries and
+  // flag the one-time notice, but only for projects that actually used it.
+  .migrate<BlockData>("Ver_2026_07_28", (prev) => {
+    const rankingOrder = prev.rankingOrder.filter(
+      (rank) => rank.value?.column !== REMOVED_IN_VIVO_SCORE_COLUMN_ID,
+    );
+    if (rankingOrder.length === prev.rankingOrder.length) return { ...prev };
+    return { ...prev, rankingOrder, inVivoScoreRemovedNotice: true };
   })
   .init(() => ({
     defaultBlockLabel: getDefaultBlockLabel({}),
@@ -101,4 +121,5 @@ export const blockDataModel = new DataModelBuilder()
     filtersInitializedForAnchor: undefined,
     rankingsInitializedForAnchor: undefined,
     preset: undefined,
+    inVivoScoreRemovedNotice: undefined,
   }));

--- a/model/src/types.ts
+++ b/model/src/types.ts
@@ -70,13 +70,22 @@ export type BlockData_Ver_2026_05_08 = BlockData_Ver_2026_02_25 & {
   selectionPlotState: GraphMakerState;
 };
 
-export type BlockData = Omit<BlockData_Ver_2026_05_08, "inputAnchor"> & {
+export type BlockData_Ver_2026_05_21 = Omit<BlockData_Ver_2026_05_08, "inputAnchor"> & {
   /**
    * Dataset selection emitted by `PlDatasetSelector` (primary anchor + optional
    * filter). Replaces the previous `inputAnchor: PlRef`; the args lambda
    * unpacks it into the workflow's `inputAnchor` + `inputFilter`.
    */
   input?: DatasetSelection;
+};
+
+export type BlockData = BlockData_Ver_2026_05_21 & {
+  /**
+   * Set by the `Ver_2026_07_28` migration when it dropped the block's former
+   * built-in "In Vivo Score" from the stored ranking. Drives a one-time notice
+   * on the main page; cleared when the user dismisses it.
+   */
+  inVivoScoreRemovedNotice?: boolean;
 };
 
 export type BlockArgs = {

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -76,6 +76,15 @@ const kabatNumbering = computed<boolean>({
   set: (v: boolean) => (app.model.data.kabatNumbering = v),
 });
 
+// One-time notice for projects whose stored ranking was cleaned up by the
+// Ver_2026_07_28 migration. Dismissing it clears the flag for good.
+const inVivoScoreNoticeVisible = computed<boolean>({
+  get: () => app.model.data.inVivoScoreRemovedNotice === true,
+  set: (v: boolean) => {
+    if (!v) app.model.data.inVivoScoreRemovedNotice = false;
+  },
+});
+
 // Special value for "No diversification" option
 const NO_DIVERSIFICATION_VALUE = "__no_diversification__";
 
@@ -223,6 +232,16 @@ watch(
       </PlBtnGhost>
       <PlBtnGhost icon="settings" @click.stop="() => (settingsOpen = true)"> Settings </PlBtnGhost>
     </template>
+    <PlAlert
+      v-model="inVivoScoreNoticeVisible"
+      type="warn"
+      label="In Vivo Score removed"
+      closeable
+    >
+      From this version on, Lead Selection no longer computes its own In Vivo Score, and the ranking
+      column using it has been removed from this project. The score is now produced by the
+      Repertoire Score block — add it upstream and rank by its Repertoire Score column instead.
+    </PlAlert>
     <PlAlert v-if="app.model.outputs.kabatWarning" type="warn">
       {{ app.model.outputs.kabatWarning }}
     </PlAlert>

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -232,12 +232,7 @@ watch(
       </PlBtnGhost>
       <PlBtnGhost icon="settings" @click.stop="() => (settingsOpen = true)"> Settings </PlBtnGhost>
     </template>
-    <PlAlert
-      v-model="inVivoScoreNoticeVisible"
-      type="warn"
-      label="In Vivo Score removed"
-      closeable
-    >
+    <PlAlert v-model="inVivoScoreNoticeVisible" type="warn" label="In Vivo Score removed" closeable>
       From this version on, Lead Selection no longer computes its own In Vivo Score, and the ranking
       column using it has been removed from this project. The score is now produced by the
       Repertoire Score block — add it upstream and rank by its Repertoire Score column instead.


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a versioned migration that removes obsolete In Vivo Score rankings and shows affected projects a dismissible migration notice.
- **BlockData_Ver_2026_05_21** — The persisted model shape introduced by the previous dataset-selection migration; extracted as a distinct type so the new migration has an accurate input version.
- **BlockData** — The current persisted model shape; extended with the optional `inVivoScoreRemovedNotice` flag.
- **RankingOrder** — The stored ordered list of columns used to rank leads; entries referencing the removed built-in In Vivo Score are now filtered during migration.
- **REMOVED_IN_VIVO_SCORE_COLUMN_ID** — The sentinel object ID for the former built-in In Vivo Score column; introduced to identify obsolete ranking entries.
- **inVivoScoreRemovedNotice** — A one-time persisted flag set only when migration removes an obsolete ranking; the UI clears it when the warning is dismissed.
- **Repertoire Score** — The upstream replacement for the removed built-in score; the new notice directs users to add its block and rank by its output column.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no concrete changed-code-triggered failures were identified.

The migration preserves unaffected rankings, removes only entries matching the obsolete score identifier, and limits the dismissible notice to projects whose stored ranking was changed.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model/src/dataModel.ts | Adds the July migration, removes rankings referencing the obsolete score identifier, and flags affected projects for notification. |
| model/src/types.ts | Separates the May persisted-data version from the current shape and adds the optional migration-notice field. |
| ui/src/pages/MainPage.vue | Displays a closeable warning for migrated projects and clears its persisted flag when dismissed. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Stored Ver_2026_05_21 project] --> B{Ranking contains removed In Vivo Score ID?}
  B -- No --> C[Preserve ranking state]
  B -- Yes --> D[Remove obsolete ranking entries]
  D --> E[Set migration notice flag]
  E --> F[Display warning on MainPage]
  F --> G[User dismisses warning]
  G --> H[Persist notice flag as false]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["format UI"](https://github.com/platforma-open/antibody-tcr-lead-selection/commit/60954a7e467f3f2c24d587182c01de030173a428) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47952535)</sub>

<!-- /greptile_comment -->