### PR TITLE
Julenmendieta/milab 6673 filter missing clonotypes

### DIFF
--- a/.changeset/require-target-presence-for-cluster-scores.md
+++ b/.changeset/require-target-presence-for-cluster-scores.md
@@ -1,0 +1,37 @@
+---
+'@platforma-open/milaboratories.top-antibodies.workflow': minor
+'@platforma-open/milaboratories.top-antibodies.sample-clonotypes': minor
+---
+
+Require target presence when ranking or filtering by cluster-level enrichment scores
+
+An enrichment score computed at cluster resolution says nothing about whether an
+individual clonotype or peptide was observed in that target's selection rounds. A
+cluster could be strongly enriched while one of its members was never seen in the
+target at all, and that member could still be selected as a lead — under
+diversified ranking it could even become its cluster's representative, since the
+cluster contributes one lead regardless of how thin its surviving members are.
+
+Selection now enforces a precondition: whenever a filter or ranking column comes
+from an enrichment block, that block's own per-element Max Frequency must be
+greater than zero. Sources are identified by the `pl7.app/blockId` domain carried
+by every enrichment export and matched to the Max Frequency column of the same
+block, so with several enrichment blocks upstream each referenced target is
+required independently (AND). Cluster columns from other blocks — clustering,
+3d-structure-clustering — own no Max Frequency column and therefore gate nothing.
+
+The precondition is not a user-editable filter, since results that ignore it are
+wrong rather than differently-scoped. It is reported in the Selection Plot as a
+single funnel stage named "Present in target(s)", placed ahead of the user
+filters, so the number of candidates it removes is visible. Max Frequency remains
+available as a normal filter for anyone wanting a stricter threshold; a user
+filter can only tighten the requirement, never relax it.
+
+An enrichment block that ran before per-element Max Frequency was exported has no
+column to check against. The precondition is then skipped for that source, and if
+no source resolves one, no stage is emitted at all — so the absence of the stage
+in the funnel reports honestly that the check did not run.
+
+Existing projects will select fewer leads after re-running when candidates were
+previously admitted on cluster-level evidence alone, and user filter stages shift
+by one in the Selection Plot to make room for the new first stage.

--- a/.changeset/require-target-presence-for-cluster-scores.md
+++ b/.changeset/require-target-presence-for-cluster-scores.md
@@ -1,37 +1,15 @@
 ---
 '@platforma-open/milaboratories.top-antibodies.workflow': minor
 '@platforma-open/milaboratories.top-antibodies.sample-clonotypes': minor
+'@platforma-open/milaboratories.top-antibodies': minor
 ---
 
-Require target presence when ranking or filtering by cluster-level enrichment scores
+Require evidence that a clonotype was present in the target before ranking or filtering by cluster-level enrichment
 
-An enrichment score computed at cluster resolution says nothing about whether an
-individual clonotype or peptide was observed in that target's selection rounds. A
-cluster could be strongly enriched while one of its members was never seen in the
-target at all, and that member could still be selected as a lead — under
-diversified ranking it could even become its cluster's representative, since the
-cluster contributes one lead regardless of how thin its surviving members are.
+A cluster-level enrichment score describes the cluster, not its individual members, so a
+clonotype never observed in a target's selection rounds could still be selected as a lead.
+Selection now requires that clonotype's own Max Frequency in that target to be above zero,
+checked independently for each target.
 
-Selection now enforces a precondition: whenever a filter or ranking column comes
-from an enrichment block, that block's own per-element Max Frequency must be
-greater than zero. Sources are identified by the `pl7.app/blockId` domain carried
-by every enrichment export and matched to the Max Frequency column of the same
-block, so with several enrichment blocks upstream each referenced target is
-required independently (AND). Cluster columns from other blocks — clustering,
-3d-structure-clustering — own no Max Frequency column and therefore gate nothing.
-
-The precondition is not a user-editable filter, since results that ignore it are
-wrong rather than differently-scoped. It is reported in the Selection Plot as a
-single funnel stage named "Present in target(s)", placed ahead of the user
-filters, so the number of candidates it removes is visible. Max Frequency remains
-available as a normal filter for anyone wanting a stricter threshold; a user
-filter can only tighten the requirement, never relax it.
-
-An enrichment block that ran before per-element Max Frequency was exported has no
-column to check against. The precondition is then skipped for that source, and if
-no source resolves one, no stage is emitted at all — so the absence of the stage
-in the funnel reports honestly that the check did not run.
-
-Existing projects will select fewer leads after re-running when candidates were
-previously admitted on cluster-level evidence alone, and user filter stages shift
-by one in the Selection Plot to make room for the new first stage.
+The Selection Plot shows this as a first funnel stage, "Observed in rounds". Existing
+projects will select fewer leads after re-running.

--- a/software/sample-clonotypes/src/filter.py
+++ b/software/sample-clonotypes/src/filter.py
@@ -106,6 +106,10 @@ def coerce_numeric_columns(df, spec_map):
     to "", so a column with any missing value arrives as Utf8 with "" in the gaps.
     Numeric comparisons need a real numeric dtype, and "" must become NaN so the
     is_not_nan() guard in apply_filter() excludes those rows.
+
+    Float64 is the target for every numeric column, integer-valued ones included:
+    the "" gaps become NaN, which no integer dtype can hold, and the comparisons in
+    apply_filter() behave the same on either dtype.
     """
     for column in spec_map.keys():
         if column not in df.columns:
@@ -119,26 +123,18 @@ def coerce_numeric_columns(df, spec_map):
         if ((data_type != "String") and (filter_type.startswith("number_"))):
 
             if df.schema[column] == pl.String:
-                print(f"Data type inconsistency in column {column}. Trying to find out if it's an integer or a float...")
-                # Check if non-empty values ("") might be integers or floats
-                non_empty_values = df.filter(pl.col(column) != "").select(pl.col(column)).to_series().to_list()
-                consensus_type = {"interger": 0, "float": 0}
-                for value in non_empty_values[:50]:
-                    if isinstance(value, int):
-                        consensus_type["interger"] += 1
-                    elif isinstance(value, float):
-                        consensus_type["float"] += 1
-                    else:
-                        print(f"Value {value} is not an integer or float. Skipping cast.")
-                # decide data type based on consensus
-                if consensus_type["interger"] > consensus_type["float"]:
-                    dtype = pl.Int32
-                    print(f"Casting column {column} to Int64 based on consensus.")
-                else:
-                    dtype = pl.Float64
-                    print(f"Casting column {column} to Float64 based on consensus.")
-                # Most tommon case is that zero values are represented as ""
-                df = df.with_columns(pl.col(column).replace("", float("NaN")).cast(dtype))
+                print(f"Data type inconsistency in column {column}. Casting to Float64.")
+                # Most common case is that zero values are represented as ""
+                nulls_before = df.select(pl.col(column).is_null().sum()).item()
+                df = df.with_columns(
+                    pl.col(column).replace("", float("NaN")).cast(pl.Float64, strict=False)
+                )
+                nulls_after = df.select(pl.col(column).is_null().sum()).item()
+                # A non-numeric value becomes null rather than aborting the run, but it
+                # then fails every numeric filter, so report it instead of losing it.
+                if nulls_after > nulls_before:
+                    print(f"Column {column}: {nulls_after - nulls_before} values could not be "
+                          f"parsed as numbers and became null. They pass no numeric filter.")
 
     return df
 

--- a/software/sample-clonotypes/src/filter.py
+++ b/software/sample-clonotypes/src/filter.py
@@ -13,6 +13,10 @@ def parse_arguments():
     parser.add_argument("--parquet", required=True, help="Path to input Parquet file")
     parser.add_argument("--out", required=True, help="Path to output Parquet file")
     parser.add_argument("--filter-map", required=True, help="JSON string containing filter mapping")
+    parser.add_argument("--precondition-map", required=False,
+                        help='JSON string mapping Precond_* columns to filter specifications, e.g. '
+                             '{"Precond_0":{"type":"number_greaterThan","reference":0,"valueType":"Double"}}. '
+                             'Applied as a single selection stage ahead of the user filters.')
     parser.add_argument("--emit-selection", required=False, help="Path to output selection stage parquet (clonotypeKey + selectionStage)")
     return parser.parse_args()
 
@@ -95,30 +99,131 @@ def drop_empty_keys(df):
     return df
 
 
-def apply_filters(df, filter_map):
+def coerce_numeric_columns(df, spec_map):
+    """Cast string-typed columns to numeric where a numeric filter targets them.
+
+    The clone table is written with parquetFileBuilder, whose naStr/nullStr default
+    to "", so a column with any missing value arrives as Utf8 with "" in the gaps.
+    Numeric comparisons need a real numeric dtype, and "" must become NaN so the
+    is_not_nan() guard in apply_filter() excludes those rows.
     """
-    Apply all filters specified in the filter_map to the DataFrame.
-    If filter_map is empty, return the input table with a "top" column added with value 1.
+    for column in spec_map.keys():
+        if column not in df.columns:
+            print(f"Column '{column}' from spec map not present in table. Skipping cast.")
+            continue
+
+        spec = spec_map[column]
+        filter_type = spec["type"]
+        data_type = spec["valueType"]
+        # Check data type if filters are non-string and correct for the given data type
+        if ((data_type != "String") and (filter_type.startswith("number_"))):
+
+            if df.schema[column] == pl.String:
+                print(f"Data type inconsistency in column {column}. Trying to find out if it's an integer or a float...")
+                # Check if non-empty values ("") might be integers or floats
+                non_empty_values = df.filter(pl.col(column) != "").select(pl.col(column)).to_series().to_list()
+                consensus_type = {"interger": 0, "float": 0}
+                for value in non_empty_values[:50]:
+                    if isinstance(value, int):
+                        consensus_type["interger"] += 1
+                    elif isinstance(value, float):
+                        consensus_type["float"] += 1
+                    else:
+                        print(f"Value {value} is not an integer or float. Skipping cast.")
+                # decide data type based on consensus
+                if consensus_type["interger"] > consensus_type["float"]:
+                    dtype = pl.Int32
+                    print(f"Casting column {column} to Int64 based on consensus.")
+                else:
+                    dtype = pl.Float64
+                    print(f"Casting column {column} to Float64 based on consensus.")
+                # Most tommon case is that zero values are represented as ""
+                df = df.with_columns(pl.col(column).replace("", float("NaN")).cast(dtype))
+
+    return df
+
+
+def apply_precondition(df, precondition_map):
+    """Apply the target-presence precondition as one combined step.
+
+    Every Precond_* column must pass its predicate (AND across enrichment
+    sources): an element judged by a source's cluster-level score must also be
+    backed by that source's own per-element Max Frequency. Unlike the user
+    filters this is not a tunable, so it is reported as a single stage rather
+    than one stage per source.
+
+    Returns (filtered df, eliminated clonotypeKey df or None).
+    """
+    precond_columns = sorted([col for col in df.columns if re.match(r'^Precond_\d+$', col)],
+                             key=lambda x: int(x[8:]))  # Extract number after "Precond_"
+
+    print(f"Found Precond_* columns: {precond_columns}")
+
+    if not precond_columns:
+        print("No Precond_* columns in table; target-presence precondition not applied.")
+        return df, None
+
+    before_keys = df.select("clonotypeKey")
+    for column_name in precond_columns:
+        spec = precondition_map.get(column_name)
+        if spec is None:
+            print(f"No precondition spec for column '{column_name}'. Skipping.")
+            continue
+        before_rows = df.height
+        df = apply_filter(df, column_name, spec["type"], spec.get("reference"))
+        print(f"Precondition '{column_name}' {spec['type']} {spec.get('reference')}: "
+              f"{before_rows} -> {df.height} rows")
+
+    eliminated = before_keys.join(df.select("clonotypeKey"), on="clonotypeKey", how="anti")
+    return df, eliminated
+
+
+def apply_filters(df, filter_map, precondition_map=None):
+    """
+    Apply the target-presence precondition and all filters specified in the
+    filter_map to the DataFrame.
+    If both maps are empty, return the input table with a "top" column added with value 1.
 
     Args:
         df: polars DataFrame
         filter_map: dictionary mapping column names to filter specifications
+        precondition_map: dictionary mapping Precond_* columns to filter
+            specifications, applied together as stage 1
 
     Returns:
         tuple of (filtered polars DataFrame, selection stage polars DataFrame)
         Selection stage DataFrame has columns: clonotypeKey, selectionStage (Int64)
-        selectionStage = filter index (1-based) that eliminated the clone,
-        or N_filters+1 for clones that survived all filters.
+        selectionStage = stage index (1-based) that eliminated the clone, or
+        N_filters+offset+1 for clones that survived everything, where offset is 1
+        when a precondition is applied and 0 otherwise.
     """
-    # If filter_map is empty, all clones survive (stage 1)
-    if not filter_map:
-        print("Filter map is empty. Returning input table with 'top' column added.")
+    precondition_map = precondition_map or {}
+
+    # If there is nothing to apply, all clones survive (stage 1)
+    if not filter_map and not precondition_map:
+        print("No filters or preconditions to apply. Returning input table with 'top' column added.")
         selection_df = df.select("clonotypeKey").with_columns(
             pl.lit(1).cast(pl.Int64).alias("selectionStage")
         )
         return df.with_columns(pl.lit(1).alias("top")), selection_df
 
     filtered_df = df.clone()
+    selection_parts = []
+
+    # Target-presence precondition: one tracked stage ahead of the user filters.
+    # The offset is derived from the map being non-empty — the same condition the
+    # workflow uses to decide whether to emit the stage label — so labels and
+    # stage numbers stay aligned even if the columns are absent from the table.
+    stage_offset = 1 if precondition_map else 0
+    if precondition_map:
+        filtered_df, eliminated_by_precondition = apply_precondition(filtered_df, precondition_map)
+        if eliminated_by_precondition is not None and eliminated_by_precondition.height > 0:
+            selection_parts.append(
+                eliminated_by_precondition.with_columns(
+                    pl.lit(1).cast(pl.Int64).alias("selectionStage")
+                )
+            )
+
     initial_rows = filtered_df.height
 
     # Find all Filter_* columns in the DataFrame
@@ -129,11 +234,17 @@ def apply_filters(df, filter_map):
     print(f"Filter map keys: {list(filter_map.keys())}")
 
     n_filters = len(filter_columns)
-    selection_parts = []
 
     # Apply filters
-    for stage_idx, column_name in enumerate(filter_columns, start=1):
-        filter_spec = filter_map[column_name]
+    for stage_idx, column_name in enumerate(filter_columns, start=stage_offset + 1):
+        filter_spec = filter_map.get(column_name)
+        if filter_spec is None:
+            # The workflow always pairs a Filter_<i> column with a filter_map entry,
+            # so this is a safety net rather than an expected state. The stage index
+            # is still consumed so stage numbers stay aligned with the workflow's
+            # stage labels; it simply eliminates nothing.
+            print(f"No filter spec for column '{column_name}'. Skipping.")
+            continue
 
         filter_type = filter_spec["type"]
         reference_value = filter_spec.get("reference")
@@ -164,14 +275,15 @@ def apply_filters(df, filter_map):
                 eliminated.with_columns(pl.lit(stage_idx).cast(pl.Int64).alias("selectionStage"))
             )
 
-    # Surviving clones get selectionStage = N_filters + 1
+    # Surviving clones get selectionStage = N_filters + offset + 1
     survivors = filtered_df.select("clonotypeKey").with_columns(
-        pl.lit(n_filters + 1).cast(pl.Int64).alias("selectionStage")
+        pl.lit(n_filters + stage_offset + 1).cast(pl.Int64).alias("selectionStage")
     )
     selection_parts.append(survivors)
 
     selection_df = pl.concat(selection_parts)
-    print(f"Selection stage tracking: {selection_df.height} total clones across {n_filters} filter stages")
+    print(f"Selection stage tracking: {selection_df.height} total clones across "
+          f"{n_filters + stage_offset} stages ({stage_offset} precondition, {n_filters} filter)")
 
     return filtered_df, selection_df
 
@@ -226,36 +338,20 @@ def main():
         print(f"Error parsing filter map JSON: {e}")
         return
 
-    # Make sure numeric columns where loaded as such
-    for column in filter_map.keys():
-        filter_spec = filter_map[column]
-        
-        filter_type = filter_spec["type"]
-        data_type = filter_spec["valueType"]
-        # Check data type if filters are non-string and correct for the given data type 
-        if ((data_type != "String") and (filter_type.startswith("number_"))):
-            
-            if filter_map[column]["type"].startswith("number_") and df.schema[column] == pl.String:
-                print("Data type inconsistency in column {column}. Trying to find out if it's an integer or a float...")
-                # Check if non-empty values ("") might be integers or floats
-                non_empty_values = df.filter(pl.col(column) != "").select(pl.col(column)).to_series().to_list()
-                consensus_type = {"interger": 0, "float": 0}
-                for value in non_empty_values[:50]:
-                    if isinstance(value, int):
-                        consensus_type["interger"] += 1
-                    elif isinstance(value, float):
-                        consensus_type["float"] += 1
-                    else:
-                        print(f"Value {value} is not an integer or float. Skipping cast.")
-                # decide data type based on consensus
-                if consensus_type["interger"] > consensus_type["float"]:
-                    dtype = pl.Int32
-                    print(f"Casting column {column} to Int64 based on consensus.")
-                else:
-                    dtype = pl.Float64
-                    print(f"Casting column {column} to Float64 based on consensus.")
-                # Most tommon case is that zero values are represented as ""
-                df = df.with_columns(pl.col(column).replace("", float("NaN")).cast(dtype))
+    # Parse precondition map from JSON string
+    precondition_map = {}
+    if args.precondition_map:
+        try:
+            precondition_map = json.loads(args.precondition_map)
+            print(f"Loaded precondition map: {precondition_map}")
+        except json.JSONDecodeError as e:
+            print(f"Error parsing precondition map JSON: {e}")
+            return
+
+    # Make sure numeric columns where loaded as such. Precondition columns need the
+    # same treatment as filter columns: they arrive as Utf8 with "" for elements the
+    # enrichment source never observed, and "" must become NaN to be excluded.
+    df = coerce_numeric_columns(df, {**filter_map, **precondition_map})
 
     # Optional primary filter (PlDatasetSelector): a pre-condition, not a tracked
     # stage. The Full join keeps all clonotypes (null/empty for those outside the
@@ -271,7 +367,7 @@ def main():
     # Apply filters
     filtering_start = time.time()
     print(f"Initial rows: {df.height}")
-    filtered_df, selection_df = apply_filters(df, filter_map)
+    filtered_df, selection_df = apply_filters(df, filter_map, precondition_map)
     filtering_time = time.time() - filtering_start
     print(f"Rows after filtering: {filtered_df.height}")
     print(f"Filtering: {filtering_time:.3f}s")

--- a/workflow/src/filter-and-sample.tpl.tengo
+++ b/workflow/src/filter-and-sample.tpl.tengo
@@ -20,12 +20,14 @@ self.body(func(inputs) {
     filterMap := inputs.filterMap
     rankingMap := inputs.rankingMap
     topClonotypes := inputs.topClonotypes
+    preconditionMap := inputs.preconditionMap
+    hasPrecondition := !is_undefined(preconditionMap) && len(preconditionMap) > 0
 
     outputs := {}
     finalClonotypes := undefined
 
     // Run filtering script with selection stage tracking
-    filterResult := exec.builder().
+    filterBuilder := exec.builder().
         software(assets.importSoftware("@platforma-open/milaboratories.top-antibodies.sample-clonotypes:filter")).
         mem("16GiB").
         cpu(1).
@@ -33,7 +35,18 @@ self.body(func(inputs) {
         arg("--parquet").arg("clonotypes.parquet").
         arg("--out").arg("filteredClonotypes.parquet").
         arg("--filter-map").arg(string(json.encode(filterMap))).
-        arg("--emit-selection").arg("selection.parquet").
+        arg("--emit-selection").arg("selection.parquet")
+
+    // Target-presence precondition, passed separately from the user filters so it
+    // collapses to a single tracked stage ahead of them. Omitted entirely when no
+    // enrichment source resolved a Max Frequency column, so a missing funnel stage
+    // truthfully means the check did not run.
+    if hasPrecondition {
+        filterBuilder = filterBuilder.
+            arg("--precondition-map").arg(string(json.encode(preconditionMap)))
+    }
+
+    filterResult := filterBuilder.
         saveFile("filteredClonotypes.parquet").
         saveFile("selection.parquet").
         printErrStreamToStdout().
@@ -100,6 +113,16 @@ self.body(func(inputs) {
     filterStageNames := inputs.filterStageNames
     valueLabels := {}
     stageIdx := 1
+    // The precondition is stage 1 whenever it is applied, matching the stage
+    // offset filter.py derives from the same non-empty precondition map.
+    if hasPrecondition {
+        preconditionStageName := inputs.preconditionStageName
+        if is_undefined(preconditionStageName) || preconditionStageName == "" {
+            preconditionStageName = "Present in target(s)"
+        }
+        valueLabels[string(stageIdx)] = preconditionStageName
+        stageIdx = stageIdx + 1
+    }
     if !is_undefined(filterStageNames) {
         for name in filterStageNames {
             valueLabels[string(stageIdx)] = name

--- a/workflow/src/filter-and-sample.tpl.tengo
+++ b/workflow/src/filter-and-sample.tpl.tengo
@@ -118,7 +118,7 @@ self.body(func(inputs) {
     if hasPrecondition {
         preconditionStageName := inputs.preconditionStageName
         if is_undefined(preconditionStageName) || preconditionStageName == "" {
-            preconditionStageName = "Present in target(s)"
+            preconditionStageName = "Observed in rounds"
         }
         valueLabels[string(stageIdx)] = preconditionStageName
         stageIdx = stageIdx + 1

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -218,7 +218,7 @@ wf.body(func(args) {
                 filterMap: filterMap,
                 rankingMap: rankingMap,
                 preconditionMap: preconditionMap,
-                preconditionStageName: "Present in target(s)",
+                preconditionStageName: "Observed in rounds",
                 datasetSpec: datasetSpec,
                 topClonotypes: args.topClonotypes,
                 diversificationColumn: clusterColumnHeader,

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -79,6 +79,17 @@ wf.prepare(func(args){
         partialAxesMatch: true
     }, "clusterSizes")
 
+    // Per-element Max Frequency from clonotype-enrichment (emitted in cluster
+    // mode only), used to enforce the target-presence precondition. One per
+    // enrichment block; matched to referenced score columns by `pl7.app/blockId`.
+    // The element axis is the anchor's row axis in every modality — clonotypeKey
+    // for VDJ, variantKey for peptides — so no per-modality handling is needed.
+    bundleBuilder.addMulti({
+        axes: [{ anchor: "main", idx: 1 }],
+        name: "pl7.app/maxFrequency",
+        partialAxesMatch: true
+    }, "maxFrequencies")
+
     // Add CDR3 sequences
 	bundleBuilder.addMulti({
 		axes: [{ anchor: "main", idx: 1 }], // Clonotype axis
@@ -183,6 +194,7 @@ wf.body(func(args) {
         cloneTable := tableInit.cloneTable
         filterMap := tableInit.filterMap
         rankingMap := tableInit.rankingMap
+        preconditionMap := tableInit.preconditionMap
         sortedLinkers := tableInit.sortedLinkers
         clusterColumnHeader := tableInit.clusterColumnHeader
         addedCols := tableInit.addedCols
@@ -205,6 +217,8 @@ wf.body(func(args) {
                 filters: args.filters,
                 filterMap: filterMap,
                 rankingMap: rankingMap,
+                preconditionMap: preconditionMap,
+                preconditionStageName: "Present in target(s)",
                 datasetSpec: datasetSpec,
                 topClonotypes: args.topClonotypes,
                 diversificationColumn: clusterColumnHeader,

--- a/workflow/src/utils.lib.tengo
+++ b/workflow/src/utils.lib.tengo
@@ -237,6 +237,88 @@ resolveClusterColumnHeader := func(args, columns, sortedLinkers) {
 }
 
 /**
+ * Collects the enrichment source block ids referenced by filter and ranking
+ * columns, in first-reference order.
+ *
+ * Every column exported by clonotype-enrichment carries the producing block's id
+ * in `pl7.app/blockId`, so that id identifies which enrichment run a score came
+ * from. Columns from other blocks are kept too when they carry a block id; they
+ * are harmless because only ids that own a Max Frequency column resolve to a
+ * precondition (see resolveTargetPresenceColumns).
+ *
+ * Order follows args.filters then args.rankingOrder — both plain lists — rather
+ * than map iteration, so the derived Precond_<k> headers are stable across runs
+ * and do not churn the exec cache key.
+ *
+ * @param columns - PBundle containing all columns
+ * @param args - Arguments containing filters and rankingOrder
+ * @return List of block id strings, first-reference order
+ */
+collectEnrichmentSourceIds := func(columns, args) {
+    refs := []
+    if len(args.filters) > 0 {
+        for filter in args.filters {
+            if filter.value != undefined {
+                refs = append(refs, filter.value.column)
+            }
+        }
+    }
+    if len(args.rankingOrder) > 0 {
+        for col in args.rankingOrder {
+            if col.value != undefined {
+                refs = append(refs, col.value.column)
+            }
+        }
+    }
+
+    seen := {}
+    ordered := []
+    for ref in refs {
+        spec := columns.getSpec(ref)
+        if is_undefined(spec) || is_undefined(spec.domain) {
+            continue
+        }
+        blockId := spec.domain["pl7.app/blockId"]
+        if is_undefined(blockId) || !is_undefined(seen[blockId]) {
+            continue
+        }
+        seen[blockId] = true
+        ordered = append(ordered, blockId)
+    }
+
+    return ordered
+}
+
+/**
+ * Resolves the per-element Max Frequency column for each enrichment source.
+ *
+ * clonotype-enrichment emits this column only when it runs on cluster abundance,
+ * and exactly one per block, so the source block id is a unique key. Sources
+ * with no match are skipped: the precondition is not applied for them, and when
+ * nothing resolves no stage is emitted at all, so the funnel's lack of the stage
+ * honestly reports that the check did not run.
+ *
+ * @param columns - PBundle containing all columns
+ * @param sourceIds - List of enrichment source block ids
+ * @return List of matched Max Frequency PColumns, in sourceIds order
+ */
+resolveTargetPresenceColumns := func(columns, sourceIds) {
+    matched := []
+    for blockId in sourceIds {
+        for col in columns.getColumns("maxFrequencies") {
+            if is_undefined(col.spec) || is_undefined(col.spec.domain) {
+                continue
+            }
+            if col.spec.domain["pl7.app/blockId"] == blockId {
+                matched = append(matched, col)
+                break
+            }
+        }
+    }
+    return matched
+}
+
+/**
  * Derives a lightweight, dense, per-clonotype presence column from a "main
  * sequence" column. The clone table is built with a Full join, which keeps only
  * the union of keys across added columns; sparse columns (e.g. enrichment, which
@@ -298,7 +380,8 @@ deriveClonotypePresence := func(mainSeqsCol, datasetSpec) {
  *        (PlDatasetSelector). Added to the clone table; clonotypes missing from it
  *        are dropped as a pre-condition in the filter software (see filter.py),
  *        not via the join, so the Full join can keep all clonotypes for the funnel.
- * @return Map with keys: cloneTable, filterMap, rankingMap, sortedLinkers, clusterColumnHeader, addedCols
+ * @return Map with keys: cloneTable, filterMap, rankingMap, preconditionMap,
+ *         sortedLinkers, clusterColumnHeader, addedCols
  */
 initializeCloneTable := func(pframes, columns, args, datasetSpec, inputFilterColumn) {
     // Build clonotype table
@@ -398,6 +481,25 @@ initializeCloneTable := func(pframes, columns, args, datasetSpec, inputFilterCol
                 addedCols = true
                 rankingMap[header] = col.rankingOrder
             }
+        }
+    }
+
+    // Target-presence precondition. A score computed at cluster resolution says
+    // nothing about whether *this* element was seen in the target selection
+    // rounds, so every enrichment source referenced by a filter or ranking column
+    // must also back the element with its own Max Frequency > 0. Enforced as a
+    // single tracked stage in the filter software (filter.py), ahead of the user
+    // filters, and never surfaced as a user-editable filter.
+    // Same-column-added-twice case (a user ranking by a source's own Max
+    // Frequency) needs an explicit id, as the filter columns above do.
+    preconditionMap := {}
+    for k, col in resolveTargetPresenceColumns(columns, collectEnrichmentSourceIds(columns, args)) {
+        header := "Precond_" + string(k)
+        cloneTable.add(col, {header: header, id: "precond_" + string(k)})
+        preconditionMap[header] = {
+            type: "number_greaterThan",
+            reference: 0,
+            valueType: col.spec.valueType
         }
     }
 
@@ -580,6 +682,7 @@ initializeCloneTable := func(pframes, columns, args, datasetSpec, inputFilterCol
         cloneTable: builtTable,
         filterMap: filterMap,
         rankingMap: rankingMap,
+        preconditionMap: preconditionMap,
         sortedLinkers: sortedLinkers,
         clusterColumnHeader: clusterColumnHeader,
         addedCols: addedCols
@@ -855,6 +958,8 @@ export {
     processRankingColumn: processRankingColumn,
     buildSortedLinkers: buildSortedLinkers,
     resolveClusterColumnHeader: resolveClusterColumnHeader,
+    collectEnrichmentSourceIds: collectEnrichmentSourceIds,
+    resolveTargetPresenceColumns: resolveTargetPresenceColumns,
     initializeCloneTable: initializeCloneTable,
     makeHeaderName: makeHeaderName,
     initializeCdr3SeqTable: initializeCdr3SeqTable,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a mandatory target-presence stage before clonotypes are ranked or filtered using cluster-level enrichment.
- **Clonotype:** An individual antibody/TCR sequence candidate; candidates must now have their own positive Max Frequency in each relevant enrichment source.
- **Cluster-level enrichment score:** A score shared by members of a sequence cluster; referenced enrichment sources now contribute a target-presence precondition.
- **Max Frequency:** The maximum per-element frequency observed across a target’s selection rounds; the workflow resolves these columns by enrichment block ID and requires values greater than zero.
- **Precondition map:** A generated mapping of `Precond_*` columns to numeric predicates; it is passed separately from user filters and applied as one combined stage.
- **Selection stage:** The stage at which a clonotype leaves the selection funnel; the new “Observed in rounds” stage precedes user-configured filters.
- Numeric filter columns are now consistently converted from string-backed Parquet values to floating-point values, with empty or unparseable values excluded from numeric filters.
- A changeset records minor releases and warns that rerunning existing projects can produce fewer selected leads.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

The workflow consistently derives the precondition, passes it to the filtering software, applies it before user filters, and offsets selection-stage labels and values using the same non-empty-map condition.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| software/sample-clonotypes/src/filter.py | Adds numeric coercion, combined target-presence filtering, and selection-stage offsets while preserving existing user-filter behavior. |
| workflow/src/utils.lib.tengo | Resolves referenced enrichment sources to per-element Max Frequency columns and adds generated preconditions to the clone table. |
| workflow/src/filter-and-sample.tpl.tengo | Passes the optional precondition map to the filtering executable and prepends its funnel-stage label. |
| workflow/src/main.tpl.tengo | Collects Max Frequency columns and wires the generated precondition into filtering and sampling. |
| .changeset/require-target-presence-for-cluster-scores.md | Documents the behavioral change, funnel stage, release impact, and expected reduction in selected leads. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Filter and ranking column references] --> B[Collect enrichment block IDs]
    B --> C[Resolve per-element Max Frequency columns]
    C --> D[Build Precond_* columns and map]
    D --> E[Coerce numeric columns]
    E --> F{Every Max Frequency > 0?}
    F -- No --> G[Selection stage: Observed in rounds]
    F -- Yes --> H[Apply user filters]
    H --> I[Rank and sample surviving clonotypes]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6673: name the presence stage &quot;Obs..."](https://github.com/platforma-open/antibody-tcr-lead-selection/commit/00ca7850567f5c4a73274f0972dfee732de9b277) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48315315)</sub>

<!-- /greptile_comment -->